### PR TITLE
PR-03: CLI argument parsing with clap

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,9 +1,177 @@
-use clap::Parser;
+use clap::{Parser, Subcommand};
+use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
 #[command(name = "pipeaudit")]
 #[command(about = "Audit tool for ClickHouse data pipelines")]
 #[command(version)]
 pub struct Cli {
-    // Subcommands will be added in PR-03
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    /// Run audit on ClickHouse tables
+    Audit(AuditArgs),
+}
+
+#[derive(Parser, Debug)]
+pub struct AuditArgs {
+    /// ClickHouse HTTP endpoint (e.g., http://localhost:8123)
+    #[arg(long, env = "CLICKHOUSE_ENDPOINT")]
+    pub endpoint: String,
+
+    /// ClickHouse user
+    #[arg(long, env = "CLICKHOUSE_USER", default_value = "default")]
+    pub user: String,
+
+    /// ClickHouse password
+    #[arg(long, env = "CLICKHOUSE_PASSWORD", default_value = "")]
+    pub password: String,
+
+    /// Database to audit
+    #[arg(long, short)]
+    pub db: String,
+
+    /// Tables to audit (comma-separated)
+    #[arg(long, short, value_delimiter = ',')]
+    pub tables: Vec<String>,
+
+    /// Output file path for JSON report
+    #[arg(long, short)]
+    pub out: PathBuf,
+
+    /// SQL file for EXPLAIN analysis (optional)
+    #[arg(long)]
+    pub sql_file: Option<PathBuf>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cli_parse_audit_command() {
+        let cli = Cli::parse_from([
+            "pipeaudit",
+            "audit",
+            "--endpoint",
+            "http://localhost:8123",
+            "--db",
+            "testdb",
+            "--tables",
+            "events,users",
+            "--out",
+            "report.json",
+        ]);
+
+        match cli.command {
+            Commands::Audit(args) => {
+                assert_eq!(args.endpoint, "http://localhost:8123");
+                assert_eq!(args.db, "testdb");
+                assert_eq!(args.tables, vec!["events", "users"]);
+                assert_eq!(args.out, PathBuf::from("report.json"));
+                assert_eq!(args.user, "default");
+                assert_eq!(args.password, "");
+            }
+        }
+    }
+
+    #[test]
+    fn test_cli_parse_single_table() {
+        let cli = Cli::parse_from([
+            "pipeaudit",
+            "audit",
+            "--endpoint",
+            "http://localhost:8123",
+            "--db",
+            "testdb",
+            "--tables",
+            "events",
+            "--out",
+            "report.json",
+        ]);
+
+        match cli.command {
+            Commands::Audit(args) => {
+                assert_eq!(args.tables, vec!["events"]);
+            }
+        }
+    }
+
+    #[test]
+    fn test_cli_parse_with_credentials() {
+        let cli = Cli::parse_from([
+            "pipeaudit",
+            "audit",
+            "--endpoint",
+            "http://localhost:8123",
+            "--user",
+            "admin",
+            "--password",
+            "secret",
+            "--db",
+            "testdb",
+            "--tables",
+            "events",
+            "--out",
+            "report.json",
+        ]);
+
+        match cli.command {
+            Commands::Audit(args) => {
+                assert_eq!(args.user, "admin");
+                assert_eq!(args.password, "secret");
+            }
+        }
+    }
+
+    #[test]
+    fn test_cli_parse_with_sql_file() {
+        let cli = Cli::parse_from([
+            "pipeaudit",
+            "audit",
+            "--endpoint",
+            "http://localhost:8123",
+            "--db",
+            "testdb",
+            "--tables",
+            "events",
+            "--out",
+            "report.json",
+            "--sql-file",
+            "queries.sql",
+        ]);
+
+        match cli.command {
+            Commands::Audit(args) => {
+                assert_eq!(args.sql_file, Some(PathBuf::from("queries.sql")));
+            }
+        }
+    }
+
+    #[test]
+    fn test_cli_parse_short_flags() {
+        let cli = Cli::parse_from([
+            "pipeaudit",
+            "audit",
+            "--endpoint",
+            "http://localhost:8123",
+            "-d",
+            "testdb",
+            "-t",
+            "events,users,orders",
+            "-o",
+            "report.json",
+        ]);
+
+        match cli.command {
+            Commands::Audit(args) => {
+                assert_eq!(args.db, "testdb");
+                assert_eq!(args.tables, vec!["events", "users", "orders"]);
+                assert_eq!(args.out, PathBuf::from("report.json"));
+            }
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,19 @@
 use anyhow::Result;
 use clap::Parser;
-use pipeaudit::cli::Cli;
+use pipeaudit::cli::{Cli, Commands};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let _cli = Cli::parse();
+    let cli = Cli::parse();
+
+    match cli.command {
+        Commands::Audit(args) => {
+            println!("Auditing database: {}", args.db);
+            println!("Tables: {:?}", args.tables);
+            println!("Output: {:?}", args.out);
+            // TODO: Implement audit logic in PR-24
+        }
+    }
+
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Implement CLI argument parsing using clap derive macros
- Add `audit` subcommand with all required arguments
- Support environment variables for credentials
- Add short flags for convenience

## CLI Usage
```bash
pipeaudit audit \
  --endpoint http://localhost:8123 \
  --user default \
  --password "" \
  --db testdb \
  --tables events,users \
  --out report.json
```

## Tests Added (5)
- `test_cli_parse_audit_command` - basic parsing
- `test_cli_parse_single_table` - single table
- `test_cli_parse_with_credentials` - custom user/password
- `test_cli_parse_with_sql_file` - optional sql-file
- `test_cli_parse_short_flags` - short flags (-d, -t, -o)

## Verification
```bash
cargo test   # 5 tests pass
cargo run -- --help
cargo run -- audit --help
```

Closes #14

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)