### PR TITLE
PR-14: Rule trait and registry

### DIFF
--- a/src/rules/context.rs
+++ b/src/rules/context.rs
@@ -1,0 +1,96 @@
+use crate::report::{DiskMetrics, MergeMetrics, MutationMetrics, PartsMetrics, QueryMetrics};
+use std::collections::HashMap;
+
+/// Context passed to rules for evaluation
+#[derive(Debug, Default)]
+pub struct AuditContext {
+    /// Parts metrics per table (key: "database.table")
+    pub parts: HashMap<String, PartsMetrics>,
+    /// Merge metrics per table
+    pub merges: HashMap<String, MergeMetrics>,
+    /// Mutation metrics per table
+    pub mutations: HashMap<String, MutationMetrics>,
+    /// Disk metrics (global)
+    pub disk: Vec<DiskMetrics>,
+    /// Query metrics
+    pub queries: Vec<QueryMetrics>,
+}
+
+impl AuditContext {
+    /// Create a new empty audit context
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add parts metrics for a table
+    pub fn add_parts(&mut self, metrics: PartsMetrics) {
+        let key = format!("{}.{}", metrics.database, metrics.table);
+        self.parts.insert(key, metrics);
+    }
+
+    /// Add merge metrics for a table
+    pub fn add_merges(&mut self, metrics: MergeMetrics) {
+        let key = format!("{}.{}", metrics.database, metrics.table);
+        self.merges.insert(key, metrics);
+    }
+
+    /// Add mutation metrics for a table
+    pub fn add_mutations(&mut self, metrics: MutationMetrics) {
+        let key = format!("{}.{}", metrics.database, metrics.table);
+        self.mutations.insert(key, metrics);
+    }
+
+    /// Set disk metrics
+    pub fn set_disk(&mut self, metrics: Vec<DiskMetrics>) {
+        self.disk = metrics;
+    }
+
+    /// Set query metrics
+    pub fn set_queries(&mut self, metrics: Vec<QueryMetrics>) {
+        self.queries = metrics;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_context_new() {
+        let ctx = AuditContext::new();
+        assert!(ctx.parts.is_empty());
+        assert!(ctx.merges.is_empty());
+        assert!(ctx.disk.is_empty());
+    }
+
+    #[test]
+    fn test_context_add_parts() {
+        let mut ctx = AuditContext::new();
+        ctx.add_parts(PartsMetrics {
+            database: "testdb".to_string(),
+            table: "events".to_string(),
+            active_parts: 100,
+            ..Default::default()
+        });
+
+        assert!(ctx.parts.contains_key("testdb.events"));
+        assert_eq!(ctx.parts["testdb.events"].active_parts, 100);
+    }
+
+    #[test]
+    fn test_context_add_multiple_tables() {
+        let mut ctx = AuditContext::new();
+        ctx.add_parts(PartsMetrics {
+            database: "db".to_string(),
+            table: "t1".to_string(),
+            ..Default::default()
+        });
+        ctx.add_parts(PartsMetrics {
+            database: "db".to_string(),
+            table: "t2".to_string(),
+            ..Default::default()
+        });
+
+        assert_eq!(ctx.parts.len(), 2);
+    }
+}

--- a/src/rules/engine.rs
+++ b/src/rules/engine.rs
@@ -1,0 +1,171 @@
+use crate::report::{Action, Finding};
+use super::context::AuditContext;
+
+/// Result of a rule evaluation
+#[derive(Debug)]
+pub struct RuleResult {
+    pub finding: Finding,
+    pub actions: Vec<Action>,
+}
+
+/// Trait for implementing audit rules
+pub trait Rule: Send + Sync {
+    /// Unique identifier for the rule
+    fn id(&self) -> &'static str;
+
+    /// Human-readable name
+    fn name(&self) -> &'static str;
+
+    /// Evaluate the rule against the audit context
+    fn evaluate(&self, ctx: &AuditContext) -> Vec<RuleResult>;
+}
+
+/// Registry for managing and running rules
+#[derive(Default)]
+pub struct RuleRegistry {
+    rules: Vec<Box<dyn Rule>>,
+}
+
+impl RuleRegistry {
+    /// Create a new empty rule registry
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a rule
+    pub fn register(&mut self, rule: Box<dyn Rule>) {
+        self.rules.push(rule);
+    }
+
+    /// Evaluate all rules against the context
+    pub fn evaluate_all(&self, ctx: &AuditContext) -> Vec<RuleResult> {
+        self.rules
+            .iter()
+            .flat_map(|rule| rule.evaluate(ctx))
+            .collect()
+    }
+
+    /// Get the number of registered rules
+    pub fn len(&self) -> usize {
+        self.rules.len()
+    }
+
+    /// Check if registry is empty
+    pub fn is_empty(&self) -> bool {
+        self.rules.is_empty()
+    }
+
+    /// Get list of registered rule IDs
+    pub fn rule_ids(&self) -> Vec<&'static str> {
+        self.rules.iter().map(|r| r.id()).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::report::Severity;
+
+    // Mock rule for testing
+    struct MockRule {
+        should_trigger: bool,
+    }
+
+    impl Rule for MockRule {
+        fn id(&self) -> &'static str {
+            "mock_rule"
+        }
+
+        fn name(&self) -> &'static str {
+            "Mock Rule"
+        }
+
+        fn evaluate(&self, _ctx: &AuditContext) -> Vec<RuleResult> {
+            if self.should_trigger {
+                vec![RuleResult {
+                    finding: Finding {
+                        id: "f-mock".to_string(),
+                        rule_id: self.id().to_string(),
+                        severity: Severity::Warning,
+                        target: "test".to_string(),
+                        message: "Mock finding".to_string(),
+                        evidence_refs: vec![],
+                        confidence: 1.0,
+                    },
+                    actions: vec![],
+                }]
+            } else {
+                vec![]
+            }
+        }
+    }
+
+    #[test]
+    fn test_registry_empty() {
+        let registry = RuleRegistry::new();
+        assert!(registry.is_empty());
+        assert_eq!(registry.len(), 0);
+    }
+
+    #[test]
+    fn test_registry_register() {
+        let mut registry = RuleRegistry::new();
+        registry.register(Box::new(MockRule { should_trigger: false }));
+
+        assert!(!registry.is_empty());
+        assert_eq!(registry.len(), 1);
+    }
+
+    #[test]
+    fn test_registry_evaluate_empty() {
+        let registry = RuleRegistry::new();
+        let ctx = AuditContext::new();
+
+        let results = registry.evaluate_all(&ctx);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_registry_evaluate_no_trigger() {
+        let mut registry = RuleRegistry::new();
+        registry.register(Box::new(MockRule { should_trigger: false }));
+
+        let ctx = AuditContext::new();
+        let results = registry.evaluate_all(&ctx);
+
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_registry_evaluate_trigger() {
+        let mut registry = RuleRegistry::new();
+        registry.register(Box::new(MockRule { should_trigger: true }));
+
+        let ctx = AuditContext::new();
+        let results = registry.evaluate_all(&ctx);
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].finding.rule_id, "mock_rule");
+    }
+
+    #[test]
+    fn test_registry_multiple_rules() {
+        let mut registry = RuleRegistry::new();
+        registry.register(Box::new(MockRule { should_trigger: true }));
+        registry.register(Box::new(MockRule { should_trigger: true }));
+
+        let ctx = AuditContext::new();
+        let results = registry.evaluate_all(&ctx);
+
+        assert_eq!(results.len(), 2);
+    }
+
+    #[test]
+    fn test_registry_rule_ids() {
+        let mut registry = RuleRegistry::new();
+        registry.register(Box::new(MockRule { should_trigger: false }));
+
+        let ids = registry.rule_ids();
+        assert_eq!(ids, vec!["mock_rule"]);
+    }
+}

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -1,2 +1,5 @@
-// Rules module - finding and action generation
-// Implementation will be added in PR-14 to PR-19
+mod context;
+mod engine;
+
+pub use context::AuditContext;
+pub use engine::{Rule, RuleRegistry, RuleResult};


### PR DESCRIPTION
## Summary
Implement the core rule engine framework.

## Rule Trait
```rust
pub trait Rule: Send + Sync {
    fn id(&self) -> &'static str;
    fn name(&self) -> &'static str;
    fn evaluate(&self, ctx: &AuditContext) -> Vec<RuleResult>;
}
```

## RuleRegistry
```rust
let mut registry = RuleRegistry::new();
registry.register(Box::new(MyRule));
let results = registry.evaluate_all(&ctx);
```

## AuditContext
```rust
let mut ctx = AuditContext::new();
ctx.add_parts(parts_metrics);
ctx.add_merges(merge_metrics);
ctx.set_disk(disk_metrics);
ctx.set_queries(query_metrics);
```

## Tests (10)
- Context: new, add_parts, add_multiple_tables
- Registry: empty, register, evaluate_empty, evaluate_no_trigger, evaluate_trigger, multiple_rules, rule_ids

Closes #25

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)