### PR TITLE
PR-16 to PR-19: All 5 finding rules

### DIFF
--- a/src/rules/disk.rs
+++ b/src/rules/disk.rs
@@ -1,0 +1,131 @@
+use crate::report::{Action, ActionType, Finding, Priority, Severity};
+use super::{AuditContext, Rule, RuleResult};
+
+const DISK_WARNING_PCT: f64 = 20.0;
+const DISK_CRITICAL_PCT: f64 = 10.0;
+
+/// Rule to detect low disk headroom
+pub struct DiskHeadroomRule;
+
+impl Rule for DiskHeadroomRule {
+    fn id(&self) -> &'static str {
+        "disk_headroom"
+    }
+
+    fn name(&self) -> &'static str {
+        "Disk Headroom"
+    }
+
+    fn evaluate(&self, ctx: &AuditContext) -> Vec<RuleResult> {
+        let mut results = Vec::new();
+
+        for disk in &ctx.disk {
+            let free_pct = disk.free_percent;
+            let free_gb = disk.free_space as f64 / 1_073_741_824.0;
+
+            if free_pct < DISK_CRITICAL_PCT {
+                results.push(RuleResult {
+                    finding: Finding {
+                        id: format!("f-disk-{}", results.len() + 1),
+                        rule_id: self.id().to_string(),
+                        severity: Severity::Critical,
+                        target: disk.disk_name.clone(),
+                        message: format!(
+                            "Disk {} has only {:.1}% free ({:.1}GB)",
+                            disk.disk_name, free_pct, free_gb
+                        ),
+                        evidence_refs: vec![],
+                        confidence: 1.0,
+                    },
+                    actions: vec![Action {
+                        id: format!("a-disk-{}", results.len() + 1),
+                        finding_ref: format!("f-disk-{}", results.len() + 1),
+                        action_type: ActionType::Recommendation,
+                        priority: Priority::High,
+                        description: "Expand storage or implement TTL policy urgently".to_string(),
+                        sql: None,
+                    }],
+                });
+            } else if free_pct < DISK_WARNING_PCT {
+                results.push(RuleResult {
+                    finding: Finding {
+                        id: format!("f-disk-{}", results.len() + 1),
+                        rule_id: self.id().to_string(),
+                        severity: Severity::Warning,
+                        target: disk.disk_name.clone(),
+                        message: format!(
+                            "Disk {} has only {:.1}% free ({:.1}GB)",
+                            disk.disk_name, free_pct, free_gb
+                        ),
+                        evidence_refs: vec![],
+                        confidence: 1.0,
+                    },
+                    actions: vec![Action {
+                        id: format!("a-disk-{}", results.len() + 1),
+                        finding_ref: format!("f-disk-{}", results.len() + 1),
+                        action_type: ActionType::Recommendation,
+                        priority: Priority::Medium,
+                        description: "Consider expanding storage or implementing TTL".to_string(),
+                        sql: None,
+                    }],
+                });
+            }
+        }
+
+        results
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::report::DiskMetrics;
+
+    fn ctx_with_disk(free_percent: f64) -> AuditContext {
+        let mut ctx = AuditContext::new();
+        let total = 100_000_000_000u64;
+        let free = (total as f64 * free_percent / 100.0) as u64;
+        ctx.set_disk(vec![DiskMetrics {
+            disk_name: "default".to_string(),
+            path: "/var/lib/clickhouse".to_string(),
+            total_space: total,
+            free_space: free,
+            free_percent,
+        }]);
+        ctx
+    }
+
+    #[test]
+    fn test_disk_healthy() {
+        let rule = DiskHeadroomRule;
+        let ctx = ctx_with_disk(50.0);
+        let results = rule.evaluate(&ctx);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_disk_warning() {
+        let rule = DiskHeadroomRule;
+        let ctx = ctx_with_disk(15.0);
+        let results = rule.evaluate(&ctx);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].finding.severity, Severity::Warning);
+    }
+
+    #[test]
+    fn test_disk_critical() {
+        let rule = DiskHeadroomRule;
+        let ctx = ctx_with_disk(5.0);
+        let results = rule.evaluate(&ctx);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].finding.severity, Severity::Critical);
+    }
+
+    #[test]
+    fn test_disk_at_warning_threshold() {
+        let rule = DiskHeadroomRule;
+        let ctx = ctx_with_disk(20.0);
+        let results = rule.evaluate(&ctx);
+        assert!(results.is_empty());
+    }
+}

--- a/src/rules/merges.rs
+++ b/src/rules/merges.rs
@@ -1,0 +1,122 @@
+use crate::report::{Action, ActionType, Finding, Priority, Severity};
+use super::{AuditContext, Rule, RuleResult};
+
+const MERGE_QUEUE_WARNING: u64 = 10;
+const MERGE_ELAPSED_WARNING_SEC: f64 = 3600.0; // 1 hour
+
+/// Rule to detect merge backlog
+pub struct MergeBacklogRule;
+
+impl Rule for MergeBacklogRule {
+    fn id(&self) -> &'static str {
+        "merge_backlog"
+    }
+
+    fn name(&self) -> &'static str {
+        "Merge Backlog"
+    }
+
+    fn evaluate(&self, ctx: &AuditContext) -> Vec<RuleResult> {
+        let mut results = Vec::new();
+
+        for (table_key, metrics) in &ctx.merges {
+            let queue_high = metrics.merges_in_queue > MERGE_QUEUE_WARNING;
+            let elapsed_high = metrics.max_merge_elapsed_sec > MERGE_ELAPSED_WARNING_SEC;
+
+            if queue_high || elapsed_high {
+                let message = if queue_high && elapsed_high {
+                    format!(
+                        "Merge queue has {} items and longest merge running for {:.0}s",
+                        metrics.merges_in_queue, metrics.max_merge_elapsed_sec
+                    )
+                } else if queue_high {
+                    format!(
+                        "Merge queue has {} items (threshold: {})",
+                        metrics.merges_in_queue, MERGE_QUEUE_WARNING
+                    )
+                } else {
+                    format!(
+                        "Longest merge running for {:.0}s (threshold: {:.0}s)",
+                        metrics.max_merge_elapsed_sec, MERGE_ELAPSED_WARNING_SEC
+                    )
+                };
+
+                results.push(RuleResult {
+                    finding: Finding {
+                        id: format!("f-merge-{}", results.len() + 1),
+                        rule_id: self.id().to_string(),
+                        severity: Severity::Warning,
+                        target: table_key.clone(),
+                        message,
+                        evidence_refs: vec![],
+                        confidence: 1.0,
+                    },
+                    actions: vec![Action {
+                        id: format!("a-merge-{}", results.len() + 1),
+                        finding_ref: format!("f-merge-{}", results.len() + 1),
+                        action_type: ActionType::Recommendation,
+                        priority: Priority::Medium,
+                        description: "Review write rate, consider throttling ingestion".to_string(),
+                        sql: None,
+                    }],
+                });
+            }
+        }
+
+        results
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::report::MergeMetrics;
+
+    fn ctx_with_merges(queue: u64, elapsed: f64) -> AuditContext {
+        let mut ctx = AuditContext::new();
+        ctx.add_merges(MergeMetrics {
+            database: "testdb".to_string(),
+            table: "events".to_string(),
+            merges_in_queue: queue,
+            max_merge_elapsed_sec: elapsed,
+            ..Default::default()
+        });
+        ctx
+    }
+
+    #[test]
+    fn test_merge_backlog_healthy() {
+        let rule = MergeBacklogRule;
+        let ctx = ctx_with_merges(5, 100.0);
+        let results = rule.evaluate(&ctx);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_merge_backlog_queue_warning() {
+        let rule = MergeBacklogRule;
+        let ctx = ctx_with_merges(15, 100.0);
+        let results = rule.evaluate(&ctx);
+        assert_eq!(results.len(), 1);
+        assert!(results[0].finding.message.contains("15 items"));
+    }
+
+    #[test]
+    fn test_merge_backlog_elapsed_warning() {
+        let rule = MergeBacklogRule;
+        let ctx = ctx_with_merges(5, 7200.0);
+        let results = rule.evaluate(&ctx);
+        assert_eq!(results.len(), 1);
+        assert!(results[0].finding.message.contains("7200s"));
+    }
+
+    #[test]
+    fn test_merge_backlog_both() {
+        let rule = MergeBacklogRule;
+        let ctx = ctx_with_merges(15, 7200.0);
+        let results = rule.evaluate(&ctx);
+        assert_eq!(results.len(), 1);
+        assert!(results[0].finding.message.contains("15 items"));
+        assert!(results[0].finding.message.contains("7200s"));
+    }
+}

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -1,7 +1,28 @@
 mod context;
+mod disk;
 mod engine;
+mod merges;
+mod mutations;
 mod parts;
+mod query;
 
 pub use context::AuditContext;
+pub use disk::DiskHeadroomRule;
 pub use engine::{Rule, RuleRegistry, RuleResult};
+pub use merges::MergeBacklogRule;
+pub use mutations::StuckMutationRule;
 pub use parts::PartsExplosionRule;
+pub use query::QueryAmplificationRule;
+
+impl RuleRegistry {
+    /// Create a registry with all default rules
+    pub fn with_default_rules() -> Self {
+        let mut registry = Self::new();
+        registry.register(Box::new(PartsExplosionRule));
+        registry.register(Box::new(MergeBacklogRule));
+        registry.register(Box::new(DiskHeadroomRule));
+        registry.register(Box::new(QueryAmplificationRule));
+        registry.register(Box::new(StuckMutationRule));
+        registry
+    }
+}

--- a/src/rules/mutations.rs
+++ b/src/rules/mutations.rs
@@ -1,0 +1,118 @@
+use crate::report::{Action, ActionType, Finding, Priority, Severity};
+use super::{AuditContext, Rule, RuleResult};
+
+const MUTATION_STUCK_SEC: u64 = 3600; // 1 hour
+
+/// Rule to detect stuck mutations
+pub struct StuckMutationRule;
+
+impl Rule for StuckMutationRule {
+    fn id(&self) -> &'static str {
+        "stuck_mutation"
+    }
+
+    fn name(&self) -> &'static str {
+        "Stuck Mutation"
+    }
+
+    fn evaluate(&self, ctx: &AuditContext) -> Vec<RuleResult> {
+        let mut results = Vec::new();
+
+        for (table_key, metrics) in &ctx.mutations {
+            if metrics.active_mutations > 0 {
+                if let Some(age) = metrics.oldest_active_mutation_age_sec {
+                    if age > MUTATION_STUCK_SEC {
+                        let hours = age as f64 / 3600.0;
+                        results.push(RuleResult {
+                            finding: Finding {
+                                id: format!("f-mutation-{}", results.len() + 1),
+                                rule_id: self.id().to_string(),
+                                severity: Severity::Critical,
+                                target: table_key.clone(),
+                                message: format!(
+                                    "Mutation running for {:.1} hours (threshold: 1 hour)",
+                                    hours
+                                ),
+                                evidence_refs: vec![],
+                                confidence: 1.0,
+                            },
+                            actions: vec![Action {
+                                id: format!("a-mutation-{}", results.len() + 1),
+                                finding_ref: format!("f-mutation-{}", results.len() + 1),
+                                action_type: ActionType::Recommendation,
+                                priority: Priority::High,
+                                description: "Investigate mutation, consider KILL MUTATION if stuck".to_string(),
+                                sql: Some(format!(
+                                    "SELECT * FROM system.mutations WHERE database = '{}' AND table = '{}' AND is_done = 0",
+                                    metrics.database, metrics.table
+                                )),
+                            }],
+                        });
+                    }
+                }
+            }
+        }
+
+        results
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::report::MutationMetrics;
+
+    fn ctx_with_mutations(active: u64, age_sec: Option<u64>) -> AuditContext {
+        let mut ctx = AuditContext::new();
+        ctx.add_mutations(MutationMetrics {
+            database: "testdb".to_string(),
+            table: "events".to_string(),
+            active_mutations: active,
+            oldest_active_mutation_age_sec: age_sec,
+            ..Default::default()
+        });
+        ctx
+    }
+
+    #[test]
+    fn test_mutation_none() {
+        let rule = StuckMutationRule;
+        let ctx = ctx_with_mutations(0, None);
+        let results = rule.evaluate(&ctx);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_mutation_active_recent() {
+        let rule = StuckMutationRule;
+        let ctx = ctx_with_mutations(1, Some(600)); // 10 minutes
+        let results = rule.evaluate(&ctx);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_mutation_stuck() {
+        let rule = StuckMutationRule;
+        let ctx = ctx_with_mutations(1, Some(7200)); // 2 hours
+        let results = rule.evaluate(&ctx);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].finding.severity, Severity::Critical);
+    }
+
+    #[test]
+    fn test_mutation_at_threshold() {
+        let rule = StuckMutationRule;
+        let ctx = ctx_with_mutations(1, Some(3600)); // exactly 1 hour
+        let results = rule.evaluate(&ctx);
+        assert!(results.is_empty()); // 3600 is NOT > 3600
+    }
+
+    #[test]
+    fn test_mutation_action_has_sql() {
+        let rule = StuckMutationRule;
+        let ctx = ctx_with_mutations(1, Some(7200));
+        let results = rule.evaluate(&ctx);
+        assert!(results[0].actions[0].sql.is_some());
+        assert!(results[0].actions[0].sql.as_ref().unwrap().contains("system.mutations"));
+    }
+}

--- a/src/rules/query.rs
+++ b/src/rules/query.rs
@@ -1,0 +1,151 @@
+use crate::report::{Action, ActionType, Finding, Priority, Severity};
+use super::{AuditContext, Rule, RuleResult};
+
+const READ_AMP_WARNING: f64 = 100.0;
+const READ_AMP_CRITICAL: f64 = 1000.0;
+
+/// Rule to detect high read amplification in queries
+pub struct QueryAmplificationRule;
+
+impl Rule for QueryAmplificationRule {
+    fn id(&self) -> &'static str {
+        "query_amplification"
+    }
+
+    fn name(&self) -> &'static str {
+        "Query Read Amplification"
+    }
+
+    fn evaluate(&self, ctx: &AuditContext) -> Vec<RuleResult> {
+        let mut results = Vec::new();
+
+        for query in &ctx.queries {
+            let amp = query.read_amplification;
+
+            if amp > READ_AMP_CRITICAL {
+                results.push(RuleResult {
+                    finding: Finding {
+                        id: format!("f-query-{}", results.len() + 1),
+                        rule_id: self.id().to_string(),
+                        severity: Severity::Critical,
+                        target: truncate_fingerprint(&query.query_fingerprint),
+                        message: format!(
+                            "Query has {:.0}x read amplification (critical threshold: {:.0}x)",
+                            amp, READ_AMP_CRITICAL
+                        ),
+                        evidence_refs: vec![],
+                        confidence: 1.0,
+                    },
+                    actions: vec![Action {
+                        id: format!("a-query-{}", results.len() + 1),
+                        finding_ref: format!("f-query-{}", results.len() + 1),
+                        action_type: ActionType::Recommendation,
+                        priority: Priority::High,
+                        description: "Review query, add PREWHERE or adjust ORDER BY".to_string(),
+                        sql: None,
+                    }],
+                });
+            } else if amp > READ_AMP_WARNING {
+                results.push(RuleResult {
+                    finding: Finding {
+                        id: format!("f-query-{}", results.len() + 1),
+                        rule_id: self.id().to_string(),
+                        severity: Severity::Warning,
+                        target: truncate_fingerprint(&query.query_fingerprint),
+                        message: format!(
+                            "Query has {:.0}x read amplification (warning threshold: {:.0}x)",
+                            amp, READ_AMP_WARNING
+                        ),
+                        evidence_refs: vec![],
+                        confidence: 1.0,
+                    },
+                    actions: vec![Action {
+                        id: format!("a-query-{}", results.len() + 1),
+                        finding_ref: format!("f-query-{}", results.len() + 1),
+                        action_type: ActionType::Recommendation,
+                        priority: Priority::Medium,
+                        description: "Consider optimizing query pattern".to_string(),
+                        sql: None,
+                    }],
+                });
+            }
+        }
+
+        results
+    }
+}
+
+fn truncate_fingerprint(fp: &str) -> String {
+    if fp.len() > 80 {
+        format!("{}...", &fp[..77])
+    } else {
+        fp.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::report::QueryMetrics;
+
+    fn ctx_with_query_amp(amp: f64) -> AuditContext {
+        let mut ctx = AuditContext::new();
+        ctx.set_queries(vec![QueryMetrics {
+            query_fingerprint: "SELECT * FROM events WHERE user_id = ?".to_string(),
+            read_amplification: amp,
+            ..Default::default()
+        }]);
+        ctx
+    }
+
+    #[test]
+    fn test_query_amp_healthy() {
+        let rule = QueryAmplificationRule;
+        let ctx = ctx_with_query_amp(50.0);
+        let results = rule.evaluate(&ctx);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_query_amp_warning() {
+        let rule = QueryAmplificationRule;
+        let ctx = ctx_with_query_amp(500.0);
+        let results = rule.evaluate(&ctx);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].finding.severity, Severity::Warning);
+    }
+
+    #[test]
+    fn test_query_amp_critical() {
+        let rule = QueryAmplificationRule;
+        let ctx = ctx_with_query_amp(2000.0);
+        let results = rule.evaluate(&ctx);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].finding.severity, Severity::Critical);
+    }
+
+    #[test]
+    fn test_query_amp_multiple() {
+        let rule = QueryAmplificationRule;
+        let mut ctx = AuditContext::new();
+        ctx.set_queries(vec![
+            QueryMetrics {
+                query_fingerprint: "q1".to_string(),
+                read_amplification: 50.0,
+                ..Default::default()
+            },
+            QueryMetrics {
+                query_fingerprint: "q2".to_string(),
+                read_amplification: 500.0,
+                ..Default::default()
+            },
+            QueryMetrics {
+                query_fingerprint: "q3".to_string(),
+                read_amplification: 2000.0,
+                ..Default::default()
+            },
+        ]);
+        let results = rule.evaluate(&ctx);
+        assert_eq!(results.len(), 2); // warning + critical, not healthy
+    }
+}


### PR DESCRIPTION
## Summary
Implement all 5 finding rules with tests.

## Rules Included

### 1. Merge Backlog Rule (#27)
- Queue threshold: > 10 merges
- Elapsed threshold: > 3600s (1 hour)
- 4 tests

### 2. Disk Headroom Rule (#28)
- Warning: < 20% free
- Critical: < 10% free
- 4 tests

### 3. Query Amplification Rule (#29)
- Warning: > 100x read amp
- Critical: > 1000x read amp
- 4 tests

### 4. Stuck Mutation Rule (#30)
- Critical: > 3600s (1 hour)
- 5 tests

### 5. Default Registry
```rust
RuleRegistry::with_default_rules()  // includes all 5 rules
```

## Total Tests: 17 new tests (35 total in rules module)

Closes #27 #28 #29 #30

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)