### PR TITLE
PR-24: Wire everything together in main audit command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,68 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache cargo registry
+        uses: Swatinem/rust-cache@v2
+
+      - name: Check formatting
+        run: cargo fmt --check
+
+      - name: Run clippy
+        run: cargo clippy -- -D warnings
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run tests
+        run: cargo test
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build release
+        run: cargo build --release
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pipeaudit-linux-x86_64
+          path: target/release/pipeaudit
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Build artifacts
+/target/
+Cargo.lock
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Test outputs
+*.log
+report*.json

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "pipeaudit"
+version = "0.1.0"
+edition = "2021"
+description = "Audit tool for ClickHouse data pipelines"
+license = "MIT"
+
+[dependencies]
+anyhow = "1"
+chrono = { version = "0.4", features = ["serde"] }
+clap = { version = "4", features = ["derive", "env"] }
+clickhouse = { version = "0.13", features = ["native-tls"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+uuid = { version = "1", features = ["v4"] }
+thiserror = "1"
+
+[dev-dependencies]
+pretty_assertions = "1"
+tempfile = "3"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,46 @@
+.PHONY: up down ps logs test-env build test lint clean
+
+# Docker Compose commands
+up:
+	docker-compose up -d
+	@echo "Waiting for ClickHouse to be ready..."
+	@until docker-compose exec -T clickhouse clickhouse-client --query "SELECT 1" 2>/dev/null; do \
+		sleep 1; \
+	done
+	@echo "ClickHouse is ready at http://localhost:8123"
+
+down:
+	docker-compose down -v
+
+ps:
+	docker-compose ps
+
+logs:
+	docker-compose logs -f clickhouse
+
+# Development commands
+build:
+	cargo build
+
+test:
+	cargo test
+
+lint:
+	cargo fmt --check
+	cargo clippy -- -D warnings
+
+# Integration test environment
+test-env: up
+	@echo "Test environment ready!"
+	@echo "  - ClickHouse: http://localhost:8123"
+	@echo "  - Database: testdb"
+	@echo "  - Tables: events, events_raw, events_daily_mv"
+
+# Run integration tests (requires ClickHouse running)
+test-integration: up
+	cargo test --ignored
+	$(MAKE) down
+
+# Clean up
+clean: down
+	cargo clean

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  clickhouse:
+    image: clickhouse/clickhouse-server:24.1
+    ports:
+      - "8123:8123"
+      - "9000:9000"
+    volumes:
+      - ./tests/fixtures/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
+    environment:
+      CLICKHOUSE_USER: default
+      CLICKHOUSE_PASSWORD: test
+    healthcheck:
+      test: ["CMD", "clickhouse-client", "--query", "SELECT 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 10

--- a/src/ch/client.rs
+++ b/src/ch/client.rs
@@ -104,23 +104,13 @@ mod tests {
 
     #[test]
     fn test_client_creation() {
-        let client = ChClient::new(
-            "http://localhost:8123",
-            "default",
-            "password",
-            "testdb",
-        );
+        let client = ChClient::new("http://localhost:8123", "default", "password", "testdb");
         assert_eq!(client.endpoint(), "http://localhost:8123");
     }
 
     #[test]
     fn test_client_clone() {
-        let client = ChClient::new(
-            "http://localhost:8123",
-            "default",
-            "",
-            "default",
-        );
+        let client = ChClient::new("http://localhost:8123", "default", "", "default");
         let cloned = client.clone();
         assert_eq!(cloned.endpoint(), client.endpoint());
     }

--- a/src/ch/client.rs
+++ b/src/ch/client.rs
@@ -1,0 +1,127 @@
+use anyhow::{Context, Result};
+use clickhouse::Client;
+use serde::Deserialize;
+
+/// ClickHouse HTTP client wrapper
+#[derive(Clone)]
+pub struct ChClient {
+    client: Client,
+    endpoint: String,
+}
+
+impl ChClient {
+    /// Create a new ClickHouse client
+    pub fn new(endpoint: &str, user: &str, password: &str, database: &str) -> Self {
+        let client = Client::default()
+            .with_url(endpoint)
+            .with_user(user)
+            .with_password(password)
+            .with_database(database);
+
+        Self {
+            client,
+            endpoint: endpoint.to_string(),
+        }
+    }
+
+    /// Test connection with SELECT 1
+    pub async fn ping(&self) -> Result<()> {
+        #[derive(Debug, Deserialize, clickhouse::Row)]
+        struct PingResult {
+            result: u8,
+        }
+
+        let result: PingResult = self
+            .client
+            .query("SELECT 1 AS result")
+            .fetch_one()
+            .await
+            .with_context(|| format!("Failed to connect to ClickHouse at {}", self.endpoint))?;
+
+        anyhow::ensure!(
+            result.result == 1,
+            "Unexpected ping result: {}",
+            result.result
+        );
+
+        Ok(())
+    }
+
+    /// Execute a query and return deserialized rows
+    pub async fn fetch_all<T>(&self, sql: &str) -> Result<Vec<T>>
+    where
+        T: clickhouse::Row + for<'a> Deserialize<'a>,
+    {
+        let rows = self
+            .client
+            .query(sql)
+            .fetch_all()
+            .await
+            .with_context(|| format!("Failed to execute query: {}", sql))?;
+
+        Ok(rows)
+    }
+
+    /// Execute a query and return a single row
+    pub async fn fetch_one<T>(&self, sql: &str) -> Result<T>
+    where
+        T: clickhouse::Row + for<'a> Deserialize<'a>,
+    {
+        let row = self
+            .client
+            .query(sql)
+            .fetch_one()
+            .await
+            .with_context(|| format!("Failed to execute query: {}", sql))?;
+
+        Ok(row)
+    }
+
+    /// Execute a query and return optional single row
+    pub async fn fetch_optional<T>(&self, sql: &str) -> Result<Option<T>>
+    where
+        T: clickhouse::Row + for<'a> Deserialize<'a>,
+    {
+        let row = self
+            .client
+            .query(sql)
+            .fetch_optional()
+            .await
+            .with_context(|| format!("Failed to execute query: {}", sql))?;
+
+        Ok(row)
+    }
+
+    /// Get the endpoint URL
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_client_creation() {
+        let client = ChClient::new(
+            "http://localhost:8123",
+            "default",
+            "password",
+            "testdb",
+        );
+        assert_eq!(client.endpoint(), "http://localhost:8123");
+    }
+
+    #[test]
+    fn test_client_clone() {
+        let client = ChClient::new(
+            "http://localhost:8123",
+            "default",
+            "",
+            "default",
+        );
+        let cloned = client.clone();
+        assert_eq!(cloned.endpoint(), client.endpoint());
+    }
+}

--- a/src/ch/mod.rs
+++ b/src/ch/mod.rs
@@ -1,2 +1,3 @@
-// ClickHouse client module
-// Implementation will be added in PR-04
+mod client;
+
+pub use client::ChClient;

--- a/src/ch/mod.rs
+++ b/src/ch/mod.rs
@@ -1,0 +1,2 @@
+// ClickHouse client module
+// Implementation will be added in PR-04

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,9 @@
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[command(name = "pipeaudit")]
+#[command(about = "Audit tool for ClickHouse data pipelines")]
+#[command(version)]
+pub struct Cli {
+    // Subcommands will be added in PR-03
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,9 +1,177 @@
-use clap::Parser;
+use clap::{Parser, Subcommand};
+use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
 #[command(name = "pipeaudit")]
 #[command(about = "Audit tool for ClickHouse data pipelines")]
 #[command(version)]
 pub struct Cli {
-    // Subcommands will be added in PR-03
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    /// Run audit on ClickHouse tables
+    Audit(AuditArgs),
+}
+
+#[derive(Parser, Debug)]
+pub struct AuditArgs {
+    /// ClickHouse HTTP endpoint (e.g., http://localhost:8123)
+    #[arg(long, env = "CLICKHOUSE_ENDPOINT")]
+    pub endpoint: String,
+
+    /// ClickHouse user
+    #[arg(long, env = "CLICKHOUSE_USER", default_value = "default")]
+    pub user: String,
+
+    /// ClickHouse password
+    #[arg(long, env = "CLICKHOUSE_PASSWORD", default_value = "")]
+    pub password: String,
+
+    /// Database to audit
+    #[arg(long, short)]
+    pub db: String,
+
+    /// Tables to audit (comma-separated)
+    #[arg(long, short, value_delimiter = ',')]
+    pub tables: Vec<String>,
+
+    /// Output file path for JSON report
+    #[arg(long, short)]
+    pub out: PathBuf,
+
+    /// SQL file for EXPLAIN analysis (optional)
+    #[arg(long)]
+    pub sql_file: Option<PathBuf>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cli_parse_audit_command() {
+        let cli = Cli::parse_from([
+            "pipeaudit",
+            "audit",
+            "--endpoint",
+            "http://localhost:8123",
+            "--db",
+            "testdb",
+            "--tables",
+            "events,users",
+            "--out",
+            "report.json",
+        ]);
+
+        match cli.command {
+            Commands::Audit(args) => {
+                assert_eq!(args.endpoint, "http://localhost:8123");
+                assert_eq!(args.db, "testdb");
+                assert_eq!(args.tables, vec!["events", "users"]);
+                assert_eq!(args.out, PathBuf::from("report.json"));
+                assert_eq!(args.user, "default");
+                assert_eq!(args.password, "");
+            }
+        }
+    }
+
+    #[test]
+    fn test_cli_parse_single_table() {
+        let cli = Cli::parse_from([
+            "pipeaudit",
+            "audit",
+            "--endpoint",
+            "http://localhost:8123",
+            "--db",
+            "testdb",
+            "--tables",
+            "events",
+            "--out",
+            "report.json",
+        ]);
+
+        match cli.command {
+            Commands::Audit(args) => {
+                assert_eq!(args.tables, vec!["events"]);
+            }
+        }
+    }
+
+    #[test]
+    fn test_cli_parse_with_credentials() {
+        let cli = Cli::parse_from([
+            "pipeaudit",
+            "audit",
+            "--endpoint",
+            "http://localhost:8123",
+            "--user",
+            "admin",
+            "--password",
+            "secret",
+            "--db",
+            "testdb",
+            "--tables",
+            "events",
+            "--out",
+            "report.json",
+        ]);
+
+        match cli.command {
+            Commands::Audit(args) => {
+                assert_eq!(args.user, "admin");
+                assert_eq!(args.password, "secret");
+            }
+        }
+    }
+
+    #[test]
+    fn test_cli_parse_with_sql_file() {
+        let cli = Cli::parse_from([
+            "pipeaudit",
+            "audit",
+            "--endpoint",
+            "http://localhost:8123",
+            "--db",
+            "testdb",
+            "--tables",
+            "events",
+            "--out",
+            "report.json",
+            "--sql-file",
+            "queries.sql",
+        ]);
+
+        match cli.command {
+            Commands::Audit(args) => {
+                assert_eq!(args.sql_file, Some(PathBuf::from("queries.sql")));
+            }
+        }
+    }
+
+    #[test]
+    fn test_cli_parse_short_flags() {
+        let cli = Cli::parse_from([
+            "pipeaudit",
+            "audit",
+            "--endpoint",
+            "http://localhost:8123",
+            "-d",
+            "testdb",
+            "-t",
+            "events,users,orders",
+            "-o",
+            "report.json",
+        ]);
+
+        match cli.command {
+            Commands::Audit(args) => {
+                assert_eq!(args.db, "testdb");
+                assert_eq!(args.tables, vec!["events", "users", "orders"]);
+                assert_eq!(args.out, PathBuf::from("report.json"));
+            }
+        }
+    }
 }

--- a/src/collectors/disk.rs
+++ b/src/collectors/disk.rs
@@ -1,0 +1,85 @@
+use crate::ch::ChClient;
+use crate::report::DiskMetrics;
+use anyhow::Result;
+use clickhouse::Row;
+use serde::Deserialize;
+
+/// Collector for disk metrics from system.disks
+pub struct DiskCollector;
+
+#[derive(Debug, Row, Deserialize)]
+struct DiskRow {
+    disk_name: String,
+    path: String,
+    total_space: u64,
+    free_space: u64,
+    free_percent: f64,
+}
+
+impl DiskCollector {
+    /// Build the SQL query for disk collection
+    pub fn build_query() -> String {
+        r#"
+        SELECT
+            name AS disk_name,
+            path,
+            total_space,
+            free_space,
+            round(100.0 * free_space / total_space, 2) AS free_percent
+        FROM system.disks
+        ORDER BY disk_name
+        "#
+        .to_string()
+    }
+
+    /// Collect disk metrics from ClickHouse
+    pub async fn collect(client: &ChClient) -> Result<Vec<DiskMetrics>> {
+        let sql = Self::build_query();
+        let rows: Vec<DiskRow> = client.fetch_all(&sql).await?;
+
+        let metrics = rows
+            .into_iter()
+            .map(|row| DiskMetrics {
+                disk_name: row.disk_name,
+                path: row.path,
+                total_space: row.total_space,
+                free_space: row.free_space,
+                free_percent: row.free_percent,
+            })
+            .collect();
+
+        Ok(metrics)
+    }
+
+    /// Get the SQL query string for evidence tracking
+    pub fn sql() -> String {
+        Self::build_query()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_disk_query_contains_system_disks() {
+        let sql = DiskCollector::build_query();
+        assert!(sql.contains("system.disks"));
+    }
+
+    #[test]
+    fn test_disk_query_calculates_free_percent() {
+        let sql = DiskCollector::build_query();
+        assert!(sql.contains("free_space / total_space"));
+        assert!(sql.contains("free_percent"));
+    }
+
+    #[test]
+    fn test_disk_query_selects_required_fields() {
+        let sql = DiskCollector::build_query();
+        assert!(sql.contains("name AS disk_name"));
+        assert!(sql.contains("path"));
+        assert!(sql.contains("total_space"));
+        assert!(sql.contains("free_space"));
+    }
+}

--- a/src/collectors/evidence.rs
+++ b/src/collectors/evidence.rs
@@ -1,0 +1,137 @@
+use crate::report::Evidence;
+
+/// Collector for tracking evidence (source SQL queries and timestamps)
+#[derive(Debug, Default)]
+pub struct EvidenceCollector {
+    evidence: Vec<Evidence>,
+}
+
+impl EvidenceCollector {
+    /// Create a new evidence collector
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record a piece of evidence and return its ID
+    pub fn record(&mut self, source: &str, sql: &str) -> String {
+        let id = format!("ev-{:03}", self.evidence.len() + 1);
+        let evidence = Evidence {
+            id: id.clone(),
+            source: source.to_string(),
+            sql: sql.trim().to_string(),
+            collected_at: chrono::Utc::now().to_rfc3339(),
+        };
+        self.evidence.push(evidence);
+        id
+    }
+
+    /// Get all collected evidence
+    pub fn get_all(&self) -> Vec<Evidence> {
+        self.evidence.clone()
+    }
+
+    /// Get evidence by ID
+    pub fn get(&self, id: &str) -> Option<&Evidence> {
+        self.evidence.iter().find(|e| e.id == id)
+    }
+
+    /// Get the count of evidence items
+    pub fn len(&self) -> usize {
+        self.evidence.len()
+    }
+
+    /// Check if evidence collector is empty
+    pub fn is_empty(&self) -> bool {
+        self.evidence.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_evidence_collector_new() {
+        let collector = EvidenceCollector::new();
+        assert!(collector.is_empty());
+        assert_eq!(collector.len(), 0);
+    }
+
+    #[test]
+    fn test_evidence_record() {
+        let mut collector = EvidenceCollector::new();
+        let id = collector.record("system.parts", "SELECT * FROM system.parts");
+
+        assert!(!id.is_empty());
+        assert_eq!(collector.len(), 1);
+        assert!(!collector.is_empty());
+    }
+
+    #[test]
+    fn test_evidence_record_returns_unique_ids() {
+        let mut collector = EvidenceCollector::new();
+
+        let id1 = collector.record("system.parts", "SELECT 1");
+        let id2 = collector.record("system.merges", "SELECT 2");
+        let id3 = collector.record("system.disks", "SELECT 3");
+
+        assert_ne!(id1, id2);
+        assert_ne!(id2, id3);
+        assert_ne!(id1, id3);
+
+        assert_eq!(id1, "ev-001");
+        assert_eq!(id2, "ev-002");
+        assert_eq!(id3, "ev-003");
+    }
+
+    #[test]
+    fn test_evidence_get_by_id() {
+        let mut collector = EvidenceCollector::new();
+        let id = collector.record("system.parts", "SELECT * FROM system.parts");
+
+        let evidence = collector.get(&id);
+        assert!(evidence.is_some());
+
+        let e = evidence.unwrap();
+        assert_eq!(e.source, "system.parts");
+        assert!(e.sql.contains("system.parts"));
+    }
+
+    #[test]
+    fn test_evidence_get_nonexistent() {
+        let collector = EvidenceCollector::new();
+        assert!(collector.get("nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_evidence_has_timestamp() {
+        let mut collector = EvidenceCollector::new();
+        collector.record("test", "SELECT 1");
+
+        let evidence = &collector.get_all()[0];
+        assert!(!evidence.collected_at.is_empty());
+        // Should be ISO8601 format
+        assert!(evidence.collected_at.contains('T'));
+    }
+
+    #[test]
+    fn test_evidence_get_all() {
+        let mut collector = EvidenceCollector::new();
+        collector.record("source1", "sql1");
+        collector.record("source2", "sql2");
+
+        let all = collector.get_all();
+        assert_eq!(all.len(), 2);
+        assert_eq!(all[0].source, "source1");
+        assert_eq!(all[1].source, "source2");
+    }
+
+    #[test]
+    fn test_evidence_trims_sql() {
+        let mut collector = EvidenceCollector::new();
+        collector.record("test", "  SELECT 1  \n  ");
+
+        let evidence = &collector.get_all()[0];
+        assert_eq!(evidence.sql, "SELECT 1");
+    }
+}

--- a/src/collectors/merges.rs
+++ b/src/collectors/merges.rs
@@ -1,0 +1,101 @@
+use crate::ch::ChClient;
+use crate::report::MergeMetrics;
+use anyhow::Result;
+use clickhouse::Row;
+use serde::Deserialize;
+
+/// Collector for merge metrics from system.merges
+pub struct MergesCollector;
+
+#[derive(Debug, Row, Deserialize)]
+struct MergesRow {
+    database: String,
+    table: String,
+    merges_in_queue: u64,
+    merge_rows_read: u64,
+    merge_bytes_read: u64,
+    max_merge_elapsed_sec: f64,
+}
+
+impl MergesCollector {
+    /// Build the SQL query for merges collection
+    pub fn build_query(database: &str, tables: &[String]) -> String {
+        let tables_list = tables
+            .iter()
+            .map(|t| format!("'{}'", t))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        format!(
+            r#"
+            SELECT
+                database,
+                table,
+                count() AS merges_in_queue,
+                sum(rows_read) AS merge_rows_read,
+                sum(bytes_read_uncompressed) AS merge_bytes_read,
+                max(elapsed) AS max_merge_elapsed_sec
+            FROM system.merges
+            WHERE database = '{database}' AND table IN ({tables_list})
+            GROUP BY database, table
+            ORDER BY table
+            "#,
+            database = database,
+            tables_list = tables_list
+        )
+    }
+
+    /// Collect merge metrics from ClickHouse
+    pub async fn collect(
+        client: &ChClient,
+        database: &str,
+        tables: &[String],
+    ) -> Result<Vec<MergeMetrics>> {
+        let sql = Self::build_query(database, tables);
+        let rows: Vec<MergesRow> = client.fetch_all(&sql).await?;
+
+        let metrics = rows
+            .into_iter()
+            .map(|row| MergeMetrics {
+                database: row.database,
+                table: row.table,
+                merges_in_queue: row.merges_in_queue,
+                merge_rows_read: row.merge_rows_read,
+                merge_bytes_read: row.merge_bytes_read,
+                max_merge_elapsed_sec: row.max_merge_elapsed_sec,
+            })
+            .collect();
+
+        Ok(metrics)
+    }
+
+    /// Get the SQL query string for evidence tracking
+    pub fn sql(database: &str, tables: &[String]) -> String {
+        Self::build_query(database, tables)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_merges_query_contains_system_merges() {
+        let sql = MergesCollector::build_query("testdb", &["events".to_string()]);
+        assert!(sql.contains("system.merges"));
+    }
+
+    #[test]
+    fn test_merges_query_has_aggregations() {
+        let sql = MergesCollector::build_query("db", &["t".to_string()]);
+        assert!(sql.contains("count() AS merges_in_queue"));
+        assert!(sql.contains("sum(rows_read)"));
+        assert!(sql.contains("max(elapsed)"));
+    }
+
+    #[test]
+    fn test_merges_query_filters_database() {
+        let sql = MergesCollector::build_query("mydb", &["t".to_string()]);
+        assert!(sql.contains("database = 'mydb'"));
+    }
+}

--- a/src/collectors/mod.rs
+++ b/src/collectors/mod.rs
@@ -2,6 +2,7 @@ mod disk;
 mod evidence;
 mod merges;
 mod mutations;
+mod mv_dag;
 mod parts;
 mod query_log;
 
@@ -9,5 +10,6 @@ pub use disk::DiskCollector;
 pub use evidence::EvidenceCollector;
 pub use merges::MergesCollector;
 pub use mutations::MutationsCollector;
+pub use mv_dag::MvDagCollector;
 pub use parts::PartsCollector;
 pub use query_log::QueryLogCollector;

--- a/src/collectors/mod.rs
+++ b/src/collectors/mod.rs
@@ -1,7 +1,9 @@
+mod disk;
 mod merges;
 mod mutations;
 mod parts;
 
+pub use disk::DiskCollector;
 pub use merges::MergesCollector;
 pub use mutations::MutationsCollector;
 pub use parts::PartsCollector;

--- a/src/collectors/mod.rs
+++ b/src/collectors/mod.rs
@@ -1,10 +1,12 @@
 mod disk;
+mod evidence;
 mod merges;
 mod mutations;
 mod parts;
 mod query_log;
 
 pub use disk::DiskCollector;
+pub use evidence::EvidenceCollector;
 pub use merges::MergesCollector;
 pub use mutations::MutationsCollector;
 pub use parts::PartsCollector;

--- a/src/collectors/mod.rs
+++ b/src/collectors/mod.rs
@@ -1,0 +1,2 @@
+// Collectors module - data collection from ClickHouse system tables
+// Implementation will be added in PR-08 to PR-12

--- a/src/collectors/mod.rs
+++ b/src/collectors/mod.rs
@@ -2,8 +2,10 @@ mod disk;
 mod merges;
 mod mutations;
 mod parts;
+mod query_log;
 
 pub use disk::DiskCollector;
 pub use merges::MergesCollector;
 pub use mutations::MutationsCollector;
 pub use parts::PartsCollector;
+pub use query_log::QueryLogCollector;

--- a/src/collectors/mod.rs
+++ b/src/collectors/mod.rs
@@ -1,5 +1,7 @@
 mod merges;
+mod mutations;
 mod parts;
 
 pub use merges::MergesCollector;
+pub use mutations::MutationsCollector;
 pub use parts::PartsCollector;

--- a/src/collectors/mod.rs
+++ b/src/collectors/mod.rs
@@ -1,3 +1,5 @@
+mod merges;
 mod parts;
 
+pub use merges::MergesCollector;
 pub use parts::PartsCollector;

--- a/src/collectors/mod.rs
+++ b/src/collectors/mod.rs
@@ -1,2 +1,3 @@
-// Collectors module - data collection from ClickHouse system tables
-// Implementation will be added in PR-08 to PR-12
+mod parts;
+
+pub use parts::PartsCollector;

--- a/src/collectors/mutations.rs
+++ b/src/collectors/mutations.rs
@@ -1,0 +1,103 @@
+use crate::ch::ChClient;
+use crate::report::MutationMetrics;
+use anyhow::Result;
+use clickhouse::Row;
+use serde::Deserialize;
+
+/// Collector for mutation metrics from system.mutations
+pub struct MutationsCollector;
+
+#[derive(Debug, Row, Deserialize)]
+struct MutationsRow {
+    database: String,
+    table: String,
+    total_mutations: u64,
+    active_mutations: u64,
+    latest_mutation_time: Option<String>,
+    oldest_active_mutation_age_sec: Option<u64>,
+}
+
+impl MutationsCollector {
+    /// Build the SQL query for mutations collection
+    pub fn build_query(database: &str, tables: &[String]) -> String {
+        let tables_list = tables
+            .iter()
+            .map(|t| format!("'{}'", t))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        format!(
+            r#"
+            SELECT
+                database,
+                table,
+                count() AS total_mutations,
+                countIf(is_done = 0) AS active_mutations,
+                toString(max(create_time)) AS latest_mutation_time,
+                maxIf(
+                    dateDiff('second', create_time, now()),
+                    is_done = 0
+                ) AS oldest_active_mutation_age_sec
+            FROM system.mutations
+            WHERE database = '{database}' AND table IN ({tables_list})
+            GROUP BY database, table
+            ORDER BY table
+            "#,
+            database = database,
+            tables_list = tables_list
+        )
+    }
+
+    /// Collect mutation metrics from ClickHouse
+    pub async fn collect(
+        client: &ChClient,
+        database: &str,
+        tables: &[String],
+    ) -> Result<Vec<MutationMetrics>> {
+        let sql = Self::build_query(database, tables);
+        let rows: Vec<MutationsRow> = client.fetch_all(&sql).await?;
+
+        let metrics = rows
+            .into_iter()
+            .map(|row| MutationMetrics {
+                database: row.database,
+                table: row.table,
+                total_mutations: row.total_mutations,
+                active_mutations: row.active_mutations,
+                latest_mutation_time: row.latest_mutation_time,
+                oldest_active_mutation_age_sec: row.oldest_active_mutation_age_sec,
+            })
+            .collect();
+
+        Ok(metrics)
+    }
+
+    /// Get the SQL query string for evidence tracking
+    pub fn sql(database: &str, tables: &[String]) -> String {
+        Self::build_query(database, tables)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mutations_query_contains_system_mutations() {
+        let sql = MutationsCollector::build_query("testdb", &["events".to_string()]);
+        assert!(sql.contains("system.mutations"));
+    }
+
+    #[test]
+    fn test_mutations_query_counts_active() {
+        let sql = MutationsCollector::build_query("db", &["t".to_string()]);
+        assert!(sql.contains("countIf(is_done = 0) AS active_mutations"));
+    }
+
+    #[test]
+    fn test_mutations_query_calculates_age() {
+        let sql = MutationsCollector::build_query("db", &["t".to_string()]);
+        assert!(sql.contains("dateDiff('second', create_time, now())"));
+        assert!(sql.contains("oldest_active_mutation_age_sec"));
+    }
+}

--- a/src/collectors/mv_dag.rs
+++ b/src/collectors/mv_dag.rs
@@ -74,8 +74,8 @@ impl MvDagCollector {
         Ok(Self::build_dag(database, tables, deps))
     }
 
-    /// Build DAG from raw data
-    pub fn build_dag(
+    /// Build DAG from raw data (internal use and testing)
+    fn build_dag(
         database: &str,
         tables: Vec<TableRow>,
         dependencies: Vec<DependencyRow>,
@@ -88,7 +88,10 @@ impl MvDagCollector {
             let key = format!("{}.{}", dep.database, dep.name);
             let dep_key = format!("{}.{}", dep.dep_database, dep.dep_table);
 
-            depends_on.entry(key.clone()).or_default().push(dep_key.clone());
+            depends_on
+                .entry(key.clone())
+                .or_default()
+                .push(dep_key.clone());
             depended_by.entry(dep_key).or_default().push(key);
         }
 
@@ -166,11 +169,7 @@ impl MvDagCollector {
                     continue;
                 }
 
-                let max_dep_depth = deps
-                    .iter()
-                    .filter_map(|d| depths.get(d))
-                    .max()
-                    .copied();
+                let max_dep_depth = deps.iter().filter_map(|d| depths.get(d)).max().copied();
 
                 if let Some(max_d) = max_dep_depth {
                     let new_depth = max_d + 1;

--- a/src/collectors/mv_dag.rs
+++ b/src/collectors/mv_dag.rs
@@ -1,0 +1,296 @@
+use crate::ch::ChClient;
+use crate::report::{MvDagEdge, MvDagNode, MvDagSection, TableType};
+use anyhow::Result;
+use clickhouse::Row;
+use serde::Deserialize;
+use std::collections::{HashMap, HashSet};
+
+/// Collector for MV dependency DAG
+pub struct MvDagCollector;
+
+#[derive(Debug, Row, Deserialize)]
+struct TableRow {
+    database: String,
+    name: String,
+    engine: String,
+}
+
+#[derive(Debug, Row, Deserialize)]
+struct DependencyRow {
+    database: String,
+    name: String,
+    dep_database: String,
+    dep_table: String,
+}
+
+impl MvDagCollector {
+    /// Build the SQL query for tables
+    pub fn build_tables_query(database: &str) -> String {
+        format!(
+            r#"
+            SELECT
+                database,
+                name,
+                engine
+            FROM system.tables
+            WHERE database = '{}'
+            ORDER BY name
+            "#,
+            database
+        )
+    }
+
+    /// Build the SQL query for dependencies
+    pub fn build_dependencies_query(database: &str) -> String {
+        format!(
+            r#"
+            SELECT
+                database,
+                name,
+                dep_database,
+                dep_table
+            FROM (
+                SELECT
+                    database,
+                    name,
+                    arrayJoin(dependencies_database) AS dep_database,
+                    arrayJoin(dependencies_table) AS dep_table
+                FROM system.tables
+                WHERE database = '{}' AND notEmpty(dependencies_table)
+            )
+            "#,
+            database
+        )
+    }
+
+    /// Collect MV DAG from ClickHouse
+    pub async fn collect(client: &ChClient, database: &str) -> Result<MvDagSection> {
+        let tables_sql = Self::build_tables_query(database);
+        let tables: Vec<TableRow> = client.fetch_all(&tables_sql).await?;
+
+        let deps_sql = Self::build_dependencies_query(database);
+        let deps: Vec<DependencyRow> = client.fetch_all(&deps_sql).await?;
+
+        Ok(Self::build_dag(database, tables, deps))
+    }
+
+    /// Build DAG from raw data
+    pub fn build_dag(
+        database: &str,
+        tables: Vec<TableRow>,
+        dependencies: Vec<DependencyRow>,
+    ) -> MvDagSection {
+        // Build dependency map: table -> [tables it depends on]
+        let mut depends_on: HashMap<String, Vec<String>> = HashMap::new();
+        let mut depended_by: HashMap<String, Vec<String>> = HashMap::new();
+
+        for dep in &dependencies {
+            let key = format!("{}.{}", dep.database, dep.name);
+            let dep_key = format!("{}.{}", dep.dep_database, dep.dep_table);
+
+            depends_on.entry(key.clone()).or_default().push(dep_key.clone());
+            depended_by.entry(dep_key).or_default().push(key);
+        }
+
+        // Calculate depths using BFS
+        let depths = Self::calculate_depths(&tables, &depends_on, database);
+
+        // Build nodes
+        let mut mv_count = 0;
+        let nodes: Vec<MvDagNode> = tables
+            .iter()
+            .map(|t| {
+                let key = format!("{}.{}", t.database, t.name);
+                let table_type = if t.engine.contains("MaterializedView") {
+                    mv_count += 1;
+                    TableType::MaterializedView
+                } else {
+                    TableType::Table
+                };
+
+                MvDagNode {
+                    name: t.name.clone(),
+                    database: t.database.clone(),
+                    table_type,
+                    engine: t.engine.clone(),
+                    depth: *depths.get(&key).unwrap_or(&0),
+                }
+            })
+            .collect();
+
+        // Build edges
+        let edges: Vec<MvDagEdge> = dependencies
+            .iter()
+            .map(|d| MvDagEdge {
+                from: format!("{}.{}", d.dep_database, d.dep_table),
+                to: format!("{}.{}", d.database, d.name),
+            })
+            .collect();
+
+        let max_depth = depths.values().copied().max().unwrap_or(0);
+
+        MvDagSection {
+            nodes,
+            edges,
+            max_depth,
+            total_tables: tables.len() - mv_count,
+            total_mvs: mv_count,
+        }
+    }
+
+    fn calculate_depths(
+        tables: &[TableRow],
+        depends_on: &HashMap<String, Vec<String>>,
+        database: &str,
+    ) -> HashMap<String, usize> {
+        let mut depths: HashMap<String, usize> = HashMap::new();
+
+        // Find root tables (no dependencies)
+        let table_keys: HashSet<String> = tables
+            .iter()
+            .map(|t| format!("{}.{}", t.database, t.name))
+            .collect();
+
+        for key in &table_keys {
+            if !depends_on.contains_key(key) {
+                depths.insert(key.clone(), 0);
+            }
+        }
+
+        // BFS to calculate depths
+        let mut changed = true;
+        while changed {
+            changed = false;
+            for (table, deps) in depends_on {
+                if !table.starts_with(&format!("{}.", database)) {
+                    continue;
+                }
+
+                let max_dep_depth = deps
+                    .iter()
+                    .filter_map(|d| depths.get(d))
+                    .max()
+                    .copied();
+
+                if let Some(max_d) = max_dep_depth {
+                    let new_depth = max_d + 1;
+                    let current = depths.get(table).copied();
+                    if current.is_none() || current.unwrap() < new_depth {
+                        depths.insert(table.clone(), new_depth);
+                        changed = true;
+                    }
+                }
+            }
+        }
+
+        depths
+    }
+
+    /// Get SQL for evidence
+    pub fn sql(database: &str) -> String {
+        format!(
+            "Tables: {} | Dependencies: {}",
+            Self::build_tables_query(database),
+            Self::build_dependencies_query(database)
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn table(name: &str, engine: &str) -> TableRow {
+        TableRow {
+            database: "testdb".to_string(),
+            name: name.to_string(),
+            engine: engine.to_string(),
+        }
+    }
+
+    fn dep(name: &str, depends_on: &str) -> DependencyRow {
+        DependencyRow {
+            database: "testdb".to_string(),
+            name: name.to_string(),
+            dep_database: "testdb".to_string(),
+            dep_table: depends_on.to_string(),
+        }
+    }
+
+    #[test]
+    fn test_dag_single_table() {
+        let tables = vec![table("events", "MergeTree")];
+        let dag = MvDagCollector::build_dag("testdb", tables, vec![]);
+
+        assert_eq!(dag.nodes.len(), 1);
+        assert_eq!(dag.max_depth, 0);
+        assert_eq!(dag.total_tables, 1);
+        assert_eq!(dag.total_mvs, 0);
+    }
+
+    #[test]
+    fn test_dag_with_mv() {
+        let tables = vec![
+            table("events", "MergeTree"),
+            table("events_daily", "MaterializedView"),
+        ];
+        let deps = vec![dep("events_daily", "events")];
+
+        let dag = MvDagCollector::build_dag("testdb", tables, deps);
+
+        assert_eq!(dag.nodes.len(), 2);
+        assert_eq!(dag.total_tables, 1);
+        assert_eq!(dag.total_mvs, 1);
+        assert_eq!(dag.max_depth, 1);
+        assert_eq!(dag.edges.len(), 1);
+    }
+
+    #[test]
+    fn test_dag_chain() {
+        // events -> events_daily -> events_weekly
+        let tables = vec![
+            table("events", "MergeTree"),
+            table("events_daily", "MaterializedView"),
+            table("events_weekly", "MaterializedView"),
+        ];
+        let deps = vec![
+            dep("events_daily", "events"),
+            dep("events_weekly", "events_daily"),
+        ];
+
+        let dag = MvDagCollector::build_dag("testdb", tables, deps);
+
+        assert_eq!(dag.max_depth, 2);
+        assert_eq!(dag.edges.len(), 2);
+    }
+
+    #[test]
+    fn test_dag_node_types() {
+        let tables = vec![
+            table("events", "MergeTree"),
+            table("events_mv", "MaterializedView"),
+        ];
+
+        let dag = MvDagCollector::build_dag("testdb", tables, vec![]);
+
+        let events = dag.nodes.iter().find(|n| n.name == "events").unwrap();
+        let mv = dag.nodes.iter().find(|n| n.name == "events_mv").unwrap();
+
+        assert_eq!(events.table_type, TableType::Table);
+        assert_eq!(mv.table_type, TableType::MaterializedView);
+    }
+
+    #[test]
+    fn test_tables_query() {
+        let sql = MvDagCollector::build_tables_query("testdb");
+        assert!(sql.contains("system.tables"));
+        assert!(sql.contains("database = 'testdb'"));
+    }
+
+    #[test]
+    fn test_dependencies_query() {
+        let sql = MvDagCollector::build_dependencies_query("testdb");
+        assert!(sql.contains("dependencies_table"));
+        assert!(sql.contains("database = 'testdb'"));
+    }
+}

--- a/src/collectors/parts.rs
+++ b/src/collectors/parts.rs
@@ -1,0 +1,139 @@
+use crate::ch::ChClient;
+use crate::report::PartsMetrics;
+use anyhow::Result;
+use clickhouse::Row;
+use serde::Deserialize;
+
+/// Collector for parts metrics from system.parts
+pub struct PartsCollector;
+
+#[derive(Debug, Row, Deserialize)]
+struct PartsRow {
+    database: String,
+    table: String,
+    parts_count: u64,
+    active_parts: u64,
+    total_rows: u64,
+    bytes_on_disk: u64,
+    oldest_part: Option<String>,
+    newest_part: Option<String>,
+}
+
+impl PartsCollector {
+    /// Build the SQL query for parts collection
+    pub fn build_query(database: &str, tables: &[String]) -> String {
+        let tables_list = tables
+            .iter()
+            .map(|t| format!("'{}'", t))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        format!(
+            r#"
+            SELECT
+                database,
+                table,
+                count() AS parts_count,
+                countIf(active) AS active_parts,
+                sum(rows) AS total_rows,
+                sum(bytes_on_disk) AS bytes_on_disk,
+                toString(min(modification_time)) AS oldest_part,
+                toString(max(modification_time)) AS newest_part
+            FROM system.parts
+            WHERE database = '{database}' AND table IN ({tables_list})
+            GROUP BY database, table
+            ORDER BY table
+            "#,
+            database = database,
+            tables_list = tables_list
+        )
+    }
+
+    /// Collect parts metrics from ClickHouse
+    pub async fn collect(
+        client: &ChClient,
+        database: &str,
+        tables: &[String],
+    ) -> Result<Vec<PartsMetrics>> {
+        let sql = Self::build_query(database, tables);
+        let rows: Vec<PartsRow> = client.fetch_all(&sql).await?;
+
+        let metrics = rows
+            .into_iter()
+            .map(|row| PartsMetrics {
+                database: row.database,
+                table: row.table,
+                parts_count: row.parts_count,
+                active_parts: row.active_parts,
+                total_rows: row.total_rows,
+                bytes_on_disk: row.bytes_on_disk,
+                oldest_part: row.oldest_part,
+                newest_part: row.newest_part,
+            })
+            .collect();
+
+        Ok(metrics)
+    }
+
+    /// Get the SQL query string for evidence tracking
+    pub fn sql(database: &str, tables: &[String]) -> String {
+        Self::build_query(database, tables)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parts_query_single_table() {
+        let sql = PartsCollector::build_query("testdb", &["events".to_string()]);
+
+        assert!(sql.contains("system.parts"));
+        assert!(sql.contains("database = 'testdb'"));
+        assert!(sql.contains("'events'"));
+        assert!(sql.contains("count() AS parts_count"));
+        assert!(sql.contains("countIf(active) AS active_parts"));
+    }
+
+    #[test]
+    fn test_parts_query_multiple_tables() {
+        let sql = PartsCollector::build_query(
+            "testdb",
+            &["events".to_string(), "users".to_string(), "orders".to_string()],
+        );
+
+        assert!(sql.contains("'events'"));
+        assert!(sql.contains("'users'"));
+        assert!(sql.contains("'orders'"));
+        assert!(sql.contains("table IN ("));
+    }
+
+    #[test]
+    fn test_parts_query_has_aggregations() {
+        let sql = PartsCollector::build_query("db", &["t".to_string()]);
+
+        assert!(sql.contains("sum(rows) AS total_rows"));
+        assert!(sql.contains("sum(bytes_on_disk) AS bytes_on_disk"));
+        assert!(sql.contains("min(modification_time)"));
+        assert!(sql.contains("max(modification_time)"));
+    }
+
+    #[test]
+    fn test_parts_query_group_by() {
+        let sql = PartsCollector::build_query("db", &["t".to_string()]);
+
+        assert!(sql.contains("GROUP BY database, table"));
+    }
+
+    #[test]
+    fn test_sql_evidence_matches_build_query() {
+        let database = "testdb";
+        let tables = vec!["events".to_string()];
+
+        let sql1 = PartsCollector::build_query(database, &tables);
+        let sql2 = PartsCollector::sql(database, &tables);
+
+        assert_eq!(sql1, sql2);
+    }
+}

--- a/src/collectors/parts.rs
+++ b/src/collectors/parts.rs
@@ -100,7 +100,11 @@ mod tests {
     fn test_parts_query_multiple_tables() {
         let sql = PartsCollector::build_query(
             "testdb",
-            &["events".to_string(), "users".to_string(), "orders".to_string()],
+            &[
+                "events".to_string(),
+                "users".to_string(),
+                "orders".to_string(),
+            ],
         );
 
         assert!(sql.contains("'events'"));

--- a/src/collectors/query_log.rs
+++ b/src/collectors/query_log.rs
@@ -1,0 +1,138 @@
+use crate::ch::ChClient;
+use crate::report::QueryMetrics;
+use anyhow::Result;
+use clickhouse::Row;
+use serde::Deserialize;
+
+/// Collector for query metrics from system.query_log
+pub struct QueryLogCollector;
+
+#[derive(Debug, Row, Deserialize)]
+struct QueryLogRow {
+    query_fingerprint: String,
+    execution_count: u64,
+    avg_duration_ms: f64,
+    total_read_rows: u64,
+    total_read_bytes: u64,
+    total_result_rows: u64,
+    read_amplification: f64,
+    avg_memory_bytes: u64,
+    sample_query: Option<String>,
+}
+
+impl QueryLogCollector {
+    /// Build the SQL query for query_log collection
+    pub fn build_query(database: &str, limit: usize) -> String {
+        format!(
+            r#"
+            SELECT
+                normalizeQuery(query) AS query_fingerprint,
+                count() AS execution_count,
+                avg(query_duration_ms) AS avg_duration_ms,
+                sum(read_rows) AS total_read_rows,
+                sum(read_bytes) AS total_read_bytes,
+                sum(result_rows) AS total_result_rows,
+                round(sum(read_rows) / greatest(sum(result_rows), 1), 2) AS read_amplification,
+                toUInt64(avg(memory_usage)) AS avg_memory_bytes,
+                any(query) AS sample_query
+            FROM system.query_log
+            WHERE
+                type = 'QueryFinish'
+                AND query_kind = 'Select'
+                AND event_date >= today() - 7
+                AND has(databases, '{database}')
+            GROUP BY query_fingerprint
+            ORDER BY total_read_rows DESC
+            LIMIT {limit}
+            "#,
+            database = database,
+            limit = limit
+        )
+    }
+
+    /// Collect query metrics from ClickHouse
+    pub async fn collect(client: &ChClient, database: &str) -> Result<Vec<QueryMetrics>> {
+        Self::collect_with_limit(client, database, 20).await
+    }
+
+    /// Collect query metrics with custom limit
+    pub async fn collect_with_limit(
+        client: &ChClient,
+        database: &str,
+        limit: usize,
+    ) -> Result<Vec<QueryMetrics>> {
+        let sql = Self::build_query(database, limit);
+        let rows: Vec<QueryLogRow> = client.fetch_all(&sql).await?;
+
+        let metrics = rows
+            .into_iter()
+            .map(|row| QueryMetrics {
+                query_fingerprint: row.query_fingerprint,
+                execution_count: row.execution_count,
+                avg_duration_ms: row.avg_duration_ms,
+                total_read_rows: row.total_read_rows,
+                total_read_bytes: row.total_read_bytes,
+                total_result_rows: row.total_result_rows,
+                read_amplification: row.read_amplification,
+                avg_memory_bytes: row.avg_memory_bytes,
+                sample_query: row.sample_query,
+            })
+            .collect();
+
+        Ok(metrics)
+    }
+
+    /// Get the SQL query string for evidence tracking
+    pub fn sql(database: &str) -> String {
+        Self::build_query(database, 20)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_querylog_query_contains_system_query_log() {
+        let sql = QueryLogCollector::build_query("testdb", 20);
+        assert!(sql.contains("system.query_log"));
+    }
+
+    #[test]
+    fn test_querylog_query_normalizes_query() {
+        let sql = QueryLogCollector::build_query("testdb", 20);
+        assert!(sql.contains("normalizeQuery(query)"));
+    }
+
+    #[test]
+    fn test_querylog_query_calculates_read_amplification() {
+        let sql = QueryLogCollector::build_query("testdb", 20);
+        assert!(sql.contains("sum(read_rows) / greatest(sum(result_rows), 1)"));
+        assert!(sql.contains("read_amplification"));
+    }
+
+    #[test]
+    fn test_querylog_query_filters_by_database() {
+        let sql = QueryLogCollector::build_query("mydb", 20);
+        assert!(sql.contains("has(databases, 'mydb')"));
+    }
+
+    #[test]
+    fn test_querylog_query_filters_select_queries() {
+        let sql = QueryLogCollector::build_query("testdb", 20);
+        assert!(sql.contains("query_kind = 'Select'"));
+        assert!(sql.contains("type = 'QueryFinish'"));
+    }
+
+    #[test]
+    fn test_querylog_query_uses_limit() {
+        let sql = QueryLogCollector::build_query("testdb", 50);
+        assert!(sql.contains("LIMIT 50"));
+    }
+
+    #[test]
+    fn test_querylog_query_orders_by_read_rows() {
+        let sql = QueryLogCollector::build_query("testdb", 20);
+        assert!(sql.contains("ORDER BY total_read_rows DESC"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod ch;
+pub mod cli;
+pub mod collectors;
+pub mod output;
+pub mod report;
+pub mod rules;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use clap::Parser;
+use pipeaudit::ch::ChClient;
 use pipeaudit::cli::{Cli, Commands};
 
 #[tokio::main]
@@ -8,6 +9,13 @@ async fn main() -> Result<()> {
 
     match cli.command {
         Commands::Audit(args) => {
+            // Connect to ClickHouse
+            let client = ChClient::new(&args.endpoint, &args.user, &args.password, &args.db);
+
+            // Test connection
+            client.ping().await?;
+            println!("Connected to ClickHouse at {}", args.endpoint);
+
             println!("Auditing database: {}", args.db);
             println!("Tables: {:?}", args.tables);
             println!("Output: {:?}", args.out);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,19 @@
 use anyhow::Result;
 use clap::Parser;
-use pipeaudit::cli::Cli;
+use pipeaudit::cli::{Cli, Commands};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let _cli = Cli::parse();
+    let cli = Cli::parse();
+
+    match cli.command {
+        Commands::Audit(args) => {
+            println!("Auditing database: {}", args.db);
+            println!("Tables: {:?}", args.tables);
+            println!("Output: {:?}", args.out);
+            // TODO: Implement audit logic in PR-24
+        }
+    }
+
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,13 @@ use anyhow::Result;
 use clap::Parser;
 use pipeaudit::ch::ChClient;
 use pipeaudit::cli::{Cli, Commands};
+use pipeaudit::collectors::{
+    DiskCollector, MergesCollector, MutationsCollector, MvDagCollector, PartsCollector,
+    QueryLogCollector,
+};
+use pipeaudit::output::{print_summary, write_report};
+use pipeaudit::report::{ReportBuilder, Targets};
+use pipeaudit::rules::RuleRegistry;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -9,19 +16,69 @@ async fn main() -> Result<()> {
 
     match cli.command {
         Commands::Audit(args) => {
-            // Connect to ClickHouse
-            let client = ChClient::new(&args.endpoint, &args.user, &args.password, &args.db);
-
-            // Test connection
-            client.ping().await?;
-            println!("Connected to ClickHouse at {}", args.endpoint);
-
-            println!("Auditing database: {}", args.db);
-            println!("Tables: {:?}", args.tables);
-            println!("Output: {:?}", args.out);
-            // TODO: Implement audit logic in PR-24
+            run_audit(args).await?;
         }
     }
+
+    Ok(())
+}
+
+async fn run_audit(args: pipeaudit::cli::AuditArgs) -> Result<()> {
+    // 1. Connect to ClickHouse
+    let client = ChClient::new(&args.endpoint, &args.user, &args.password, &args.db);
+    client.ping().await?;
+    eprintln!("Connected to ClickHouse at {}", args.endpoint);
+
+    // 2. Initialize report builder
+    let targets = Targets {
+        endpoint: args.endpoint.clone(),
+        database: args.db.clone(),
+        tables: args.tables.clone(),
+    };
+    let mut builder = ReportBuilder::new(targets);
+
+    // 3. Run collectors
+    eprintln!("Collecting parts metrics...");
+    let parts = PartsCollector::collect(&client, &args.db, &args.tables).await?;
+    let parts_sql = PartsCollector::sql(&args.db, &args.tables);
+    builder.with_parts(parts, &parts_sql);
+
+    eprintln!("Collecting merge metrics...");
+    let merges = MergesCollector::collect(&client, &args.db, &args.tables).await?;
+    let merges_sql = MergesCollector::sql(&args.db, &args.tables);
+    builder.with_merges(merges, &merges_sql);
+
+    eprintln!("Collecting mutation metrics...");
+    let mutations = MutationsCollector::collect(&client, &args.db, &args.tables).await?;
+    let mutations_sql = MutationsCollector::sql(&args.db, &args.tables);
+    builder.with_mutations(mutations, &mutations_sql);
+
+    eprintln!("Collecting disk metrics...");
+    let disk = DiskCollector::collect(&client).await?;
+    let disk_sql = DiskCollector::sql();
+    builder.with_disk(disk, &disk_sql);
+
+    eprintln!("Collecting query log metrics...");
+    let queries = QueryLogCollector::collect(&client, &args.db).await?;
+    let queries_sql = QueryLogCollector::sql(&args.db);
+    builder.with_queries(queries, &queries_sql);
+
+    eprintln!("Collecting MV dependency graph...");
+    let mv_dag = MvDagCollector::collect(&client, &args.db).await?;
+    let mv_dag_sql = MvDagCollector::sql(&args.db);
+    builder.with_mv_dag(mv_dag, &mv_dag_sql);
+
+    // 4. Run rules
+    eprintln!("Running audit rules...");
+    let registry = RuleRegistry::with_default_rules();
+    builder.run_rules(&registry);
+
+    // 5. Build report
+    let report = builder.build();
+
+    // 6. Output
+    write_report(&report, &args.out)?;
+    print_summary(&report, &args.out.to_string_lossy());
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,9 @@
+use anyhow::Result;
+use clap::Parser;
+use pipeaudit::cli::Cli;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let _cli = Cli::parse();
+    Ok(())
+}

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -1,0 +1,68 @@
+use crate::report::Report;
+use anyhow::{Context, Result};
+use std::path::Path;
+
+/// Write report to JSON file
+pub fn write_report(report: &Report, path: &Path) -> Result<()> {
+    let json = serde_json::to_string_pretty(report)
+        .context("Failed to serialize report to JSON")?;
+
+    std::fs::write(path, &json)
+        .with_context(|| format!("Failed to write report to {:?}", path))?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::report::{Report, ReportStatus, Summary, Targets};
+    use tempfile::NamedTempFile;
+
+    fn test_report() -> Report {
+        let mut report = Report::new(Targets {
+            endpoint: "http://localhost:8123".to_string(),
+            database: "testdb".to_string(),
+            tables: vec!["events".to_string()],
+        });
+        report.report_id = "test-id".to_string();
+        report
+    }
+
+    #[test]
+    fn test_write_report_creates_file() {
+        let report = test_report();
+        let temp = NamedTempFile::new().unwrap();
+
+        write_report(&report, temp.path()).unwrap();
+
+        assert!(temp.path().exists());
+        let content = std::fs::read_to_string(temp.path()).unwrap();
+        assert!(!content.is_empty());
+    }
+
+    #[test]
+    fn test_write_report_valid_json() {
+        let report = test_report();
+        let temp = NamedTempFile::new().unwrap();
+
+        write_report(&report, temp.path()).unwrap();
+
+        let content = std::fs::read_to_string(temp.path()).unwrap();
+        let parsed: Report = serde_json::from_str(&content).unwrap();
+
+        assert_eq!(report.report_id, parsed.report_id);
+    }
+
+    #[test]
+    fn test_write_report_pretty_printed() {
+        let report = test_report();
+        let temp = NamedTempFile::new().unwrap();
+
+        write_report(&report, temp.path()).unwrap();
+
+        let content = std::fs::read_to_string(temp.path()).unwrap();
+        // Pretty printed JSON has newlines
+        assert!(content.contains('\n'));
+    }
+}

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -4,11 +4,10 @@ use std::path::Path;
 
 /// Write report to JSON file
 pub fn write_report(report: &Report, path: &Path) -> Result<()> {
-    let json = serde_json::to_string_pretty(report)
-        .context("Failed to serialize report to JSON")?;
+    let json =
+        serde_json::to_string_pretty(report).context("Failed to serialize report to JSON")?;
 
-    std::fs::write(path, &json)
-        .with_context(|| format!("Failed to write report to {:?}", path))?;
+    std::fs::write(path, &json).with_context(|| format!("Failed to write report to {:?}", path))?;
 
     Ok(())
 }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,0 +1,2 @@
+// Output module - JSON and summary output
+// Implementation will be added in PR-22 and PR-23

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,2 +1,5 @@
-// Output module - JSON and summary output
-// Implementation will be added in PR-22 and PR-23
+mod json;
+mod summary;
+
+pub use json::write_report;
+pub use summary::print_summary;

--- a/src/output/summary.rs
+++ b/src/output/summary.rs
@@ -1,0 +1,161 @@
+use crate::report::{Report, ReportStatus, Severity};
+
+/// Print human-readable summary to stdout
+pub fn print_summary(report: &Report, output_path: &str) {
+    println!();
+    println!("╭───────────────────────────────────────────────────────────────╮");
+    println!("│                  PipeAudit Report Summary                     │");
+    println!("╰───────────────────────────────────────────────────────────────╯");
+    println!();
+
+    // Target info
+    println!(
+        "Target: {} / {}",
+        report.targets.endpoint, report.targets.database
+    );
+    println!("Tables: {}", report.targets.tables.join(", "));
+    println!("Generated: {}", report.generated_at);
+    println!();
+
+    // Status
+    let (status_icon, status_text) = match report.summary.status {
+        ReportStatus::Healthy => ("✅", "HEALTHY"),
+        ReportStatus::Warning => ("⚠️ ", "WARNING"),
+        ReportStatus::Critical => ("🚨", "CRITICAL"),
+    };
+    println!("Status: {} {}", status_icon, status_text);
+    println!();
+
+    // Findings
+    if !report.findings.is_empty() {
+        println!(
+            "Findings ({} total, {} critical, {} warning):",
+            report.summary.findings_count,
+            report.summary.critical_count,
+            report.summary.warning_count
+        );
+
+        for finding in &report.findings {
+            let icon = match finding.severity {
+                Severity::Critical => "🚨",
+                Severity::Warning => "⚠️ ",
+            };
+            println!(
+                "  {} [{}] {}: {}",
+                icon, finding.rule_id, finding.target, finding.message
+            );
+        }
+        println!();
+    }
+
+    // Actions
+    if !report.actions.is_empty() {
+        println!("Recommended Actions:");
+        for (i, action) in report.actions.iter().enumerate() {
+            println!(
+                "  {}. [{:?}] {}",
+                i + 1,
+                action.priority,
+                action.description
+            );
+            if let Some(sql) = &action.sql {
+                println!("     SQL: {}", truncate(sql, 60));
+            }
+        }
+        println!();
+    }
+
+    // MV DAG summary
+    if let Some(dag) = &report.sections.mv_dag {
+        println!(
+            "MV DAG: {} tables, {} materialized views, max depth {}",
+            dag.total_tables, dag.total_mvs, dag.max_depth
+        );
+        println!();
+    }
+
+    println!("Full report written to: {}", output_path);
+    println!();
+}
+
+fn truncate(s: &str, max_len: usize) -> String {
+    if s.len() > max_len {
+        format!("{}...", &s[..max_len - 3])
+    } else {
+        s.to_string()
+    }
+}
+
+/// Format summary as string (for testing)
+pub fn format_summary(report: &Report) -> String {
+    let mut output = String::new();
+
+    output.push_str(&format!(
+        "Status: {:?}\n",
+        report.summary.status
+    ));
+    output.push_str(&format!(
+        "Findings: {}\n",
+        report.summary.findings_count
+    ));
+
+    for finding in &report.findings {
+        output.push_str(&format!(
+            "[{:?}] {}: {}\n",
+            finding.severity, finding.rule_id, finding.message
+        ));
+    }
+
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::report::{Finding, Report, Targets};
+
+    fn test_report() -> Report {
+        Report::new(Targets {
+            endpoint: "http://localhost:8123".to_string(),
+            database: "testdb".to_string(),
+            tables: vec!["events".to_string()],
+        })
+    }
+
+    #[test]
+    fn test_format_summary_healthy() {
+        let report = test_report();
+        let output = format_summary(&report);
+
+        assert!(output.contains("Healthy"));
+        assert!(output.contains("Findings: 0"));
+    }
+
+    #[test]
+    fn test_format_summary_with_findings() {
+        let mut report = test_report();
+        report.findings.push(Finding {
+            id: "f-1".to_string(),
+            rule_id: "parts_explosion".to_string(),
+            severity: Severity::Warning,
+            target: "testdb.events".to_string(),
+            message: "Too many parts".to_string(),
+            evidence_refs: vec![],
+            confidence: 1.0,
+        });
+        report.summary.findings_count = 1;
+        report.summary.warning_count = 1;
+        report.summary.status = ReportStatus::Warning;
+
+        let output = format_summary(&report);
+
+        assert!(output.contains("Warning"));
+        assert!(output.contains("parts_explosion"));
+    }
+
+    #[test]
+    fn test_truncate() {
+        assert_eq!(truncate("short", 10), "short");
+        assert_eq!(truncate("this is a long string", 10), "this is...");
+    }
+}

--- a/src/output/summary.rs
+++ b/src/output/summary.rs
@@ -86,33 +86,27 @@ fn truncate(s: &str, max_len: usize) -> String {
     }
 }
 
-/// Format summary as string (for testing)
-pub fn format_summary(report: &Report) -> String {
-    let mut output = String::new();
-
-    output.push_str(&format!(
-        "Status: {:?}\n",
-        report.summary.status
-    ));
-    output.push_str(&format!(
-        "Findings: {}\n",
-        report.summary.findings_count
-    ));
-
-    for finding in &report.findings {
-        output.push_str(&format!(
-            "[{:?}] {}: {}\n",
-            finding.severity, finding.rule_id, finding.message
-        ));
-    }
-
-    output
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::report::{Finding, Report, Targets};
+
+    /// Format summary as string (for testing)
+    fn format_summary(report: &Report) -> String {
+        let mut output = String::new();
+
+        output.push_str(&format!("Status: {:?}\n", report.summary.status));
+        output.push_str(&format!("Findings: {}\n", report.summary.findings_count));
+
+        for finding in &report.findings {
+            output.push_str(&format!(
+                "[{:?}] {}: {}\n",
+                finding.severity, finding.rule_id, finding.message
+            ));
+        }
+
+        output
+    }
 
     fn test_report() -> Report {
         Report::new(Targets {

--- a/src/report/builder.rs
+++ b/src/report/builder.rs
@@ -1,6 +1,6 @@
 use super::types::*;
 use crate::collectors::EvidenceCollector;
-use crate::rules::{AuditContext, RuleRegistry, RuleResult};
+use crate::rules::{AuditContext, RuleRegistry};
 use std::collections::HashMap;
 
 /// Builder for constructing audit reports
@@ -101,13 +101,13 @@ impl ReportBuilder {
     fn build_context(&self) -> AuditContext {
         let mut ctx = AuditContext::new();
 
-        for (_, m) in &self.parts {
+        for m in self.parts.values() {
             ctx.add_parts(m.clone());
         }
-        for (_, m) in &self.merges {
+        for m in self.merges.values() {
             ctx.add_merges(m.clone());
         }
-        for (_, m) in &self.mutations {
+        for m in self.mutations.values() {
             ctx.add_mutations(m.clone());
         }
         ctx.set_disk(self.disk.clone());

--- a/src/report/builder.rs
+++ b/src/report/builder.rs
@@ -1,0 +1,304 @@
+use super::types::*;
+use crate::collectors::EvidenceCollector;
+use crate::rules::{AuditContext, RuleRegistry, RuleResult};
+use std::collections::HashMap;
+
+/// Builder for constructing audit reports
+pub struct ReportBuilder {
+    targets: Targets,
+    evidence: EvidenceCollector,
+    parts: HashMap<String, PartsMetrics>,
+    merges: HashMap<String, MergeMetrics>,
+    mutations: HashMap<String, MutationMetrics>,
+    disk: Vec<DiskMetrics>,
+    queries: Vec<QueryMetrics>,
+    mv_dag: Option<MvDagSection>,
+    findings: Vec<Finding>,
+    actions: Vec<Action>,
+}
+
+impl ReportBuilder {
+    /// Create a new report builder
+    pub fn new(targets: Targets) -> Self {
+        Self {
+            targets,
+            evidence: EvidenceCollector::new(),
+            parts: HashMap::new(),
+            merges: HashMap::new(),
+            mutations: HashMap::new(),
+            disk: Vec::new(),
+            queries: Vec::new(),
+            mv_dag: None,
+            findings: Vec::new(),
+            actions: Vec::new(),
+        }
+    }
+
+    /// Add parts metrics
+    pub fn with_parts(&mut self, metrics: Vec<PartsMetrics>, sql: &str) -> &mut Self {
+        self.evidence.record("system.parts", sql);
+        for m in metrics {
+            let key = format!("{}.{}", m.database, m.table);
+            self.parts.insert(key, m);
+        }
+        self
+    }
+
+    /// Add merge metrics
+    pub fn with_merges(&mut self, metrics: Vec<MergeMetrics>, sql: &str) -> &mut Self {
+        self.evidence.record("system.merges", sql);
+        for m in metrics {
+            let key = format!("{}.{}", m.database, m.table);
+            self.merges.insert(key, m);
+        }
+        self
+    }
+
+    /// Add mutation metrics
+    pub fn with_mutations(&mut self, metrics: Vec<MutationMetrics>, sql: &str) -> &mut Self {
+        self.evidence.record("system.mutations", sql);
+        for m in metrics {
+            let key = format!("{}.{}", m.database, m.table);
+            self.mutations.insert(key, m);
+        }
+        self
+    }
+
+    /// Add disk metrics
+    pub fn with_disk(&mut self, metrics: Vec<DiskMetrics>, sql: &str) -> &mut Self {
+        self.evidence.record("system.disks", sql);
+        self.disk = metrics;
+        self
+    }
+
+    /// Add query metrics
+    pub fn with_queries(&mut self, metrics: Vec<QueryMetrics>, sql: &str) -> &mut Self {
+        self.evidence.record("system.query_log", sql);
+        self.queries = metrics;
+        self
+    }
+
+    /// Add MV DAG
+    pub fn with_mv_dag(&mut self, dag: MvDagSection, sql: &str) -> &mut Self {
+        self.evidence.record("system.tables", sql);
+        self.mv_dag = Some(dag);
+        self
+    }
+
+    /// Run rules and collect findings
+    pub fn run_rules(&mut self, registry: &RuleRegistry) -> &mut Self {
+        let ctx = self.build_context();
+        let results = registry.evaluate_all(&ctx);
+
+        for result in results {
+            self.findings.push(result.finding);
+            self.actions.extend(result.actions);
+        }
+
+        self
+    }
+
+    fn build_context(&self) -> AuditContext {
+        let mut ctx = AuditContext::new();
+
+        for (_, m) in &self.parts {
+            ctx.add_parts(m.clone());
+        }
+        for (_, m) in &self.merges {
+            ctx.add_merges(m.clone());
+        }
+        for (_, m) in &self.mutations {
+            ctx.add_mutations(m.clone());
+        }
+        ctx.set_disk(self.disk.clone());
+        ctx.set_queries(self.queries.clone());
+
+        ctx
+    }
+
+    /// Build the final report
+    pub fn build(self) -> Report {
+        let mut report = Report::new(self.targets);
+
+        // Build sections
+        report.sections = Sections {
+            parts: if self.parts.is_empty() {
+                None
+            } else {
+                Some(PartsSection {
+                    tables: self.parts.into_values().collect(),
+                })
+            },
+            merges: if self.merges.is_empty() {
+                None
+            } else {
+                Some(MergesSection {
+                    tables: self.merges.into_values().collect(),
+                })
+            },
+            mutations: if self.mutations.is_empty() {
+                None
+            } else {
+                Some(MutationsSection {
+                    tables: self.mutations.into_values().collect(),
+                })
+            },
+            disk: if self.disk.is_empty() {
+                None
+            } else {
+                Some(DiskSection { disks: self.disk })
+            },
+            query_log: if self.queries.is_empty() {
+                None
+            } else {
+                Some(QueryLogSection {
+                    queries: self.queries,
+                })
+            },
+            mv_dag: self.mv_dag,
+        };
+
+        // Set findings and actions
+        report.findings = self.findings;
+        report.actions = self.actions;
+
+        // Calculate summary
+        let critical_count = report
+            .findings
+            .iter()
+            .filter(|f| f.severity == Severity::Critical)
+            .count();
+        let warning_count = report
+            .findings
+            .iter()
+            .filter(|f| f.severity == Severity::Warning)
+            .count();
+
+        report.summary = Summary {
+            status: if critical_count > 0 {
+                ReportStatus::Critical
+            } else if warning_count > 0 {
+                ReportStatus::Warning
+            } else {
+                ReportStatus::Healthy
+            },
+            findings_count: report.findings.len(),
+            critical_count,
+            warning_count,
+        };
+
+        // Set evidence
+        report.evidence = self.evidence.get_all();
+
+        report
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn targets() -> Targets {
+        Targets {
+            endpoint: "http://localhost:8123".to_string(),
+            database: "testdb".to_string(),
+            tables: vec!["events".to_string()],
+        }
+    }
+
+    #[test]
+    fn test_builder_empty_report() {
+        let builder = ReportBuilder::new(targets());
+        let report = builder.build();
+
+        assert_eq!(report.summary.status, ReportStatus::Healthy);
+        assert_eq!(report.findings.len(), 0);
+        assert!(report.sections.parts.is_none());
+    }
+
+    #[test]
+    fn test_builder_with_parts() {
+        let mut builder = ReportBuilder::new(targets());
+        builder.with_parts(
+            vec![PartsMetrics {
+                database: "testdb".to_string(),
+                table: "events".to_string(),
+                active_parts: 100,
+                ..Default::default()
+            }],
+            "SELECT * FROM system.parts",
+        );
+
+        let report = builder.build();
+        assert!(report.sections.parts.is_some());
+        assert_eq!(report.evidence.len(), 1);
+    }
+
+    #[test]
+    fn test_builder_with_findings() {
+        let mut builder = ReportBuilder::new(targets());
+        builder.with_parts(
+            vec![PartsMetrics {
+                database: "testdb".to_string(),
+                table: "events".to_string(),
+                active_parts: 1500, // Will trigger critical
+                ..Default::default()
+            }],
+            "sql",
+        );
+
+        let registry = RuleRegistry::with_default_rules();
+        builder.run_rules(&registry);
+
+        let report = builder.build();
+        assert_eq!(report.summary.status, ReportStatus::Critical);
+        assert!(!report.findings.is_empty());
+    }
+
+    #[test]
+    fn test_builder_status_escalation() {
+        let mut builder = ReportBuilder::new(targets());
+
+        // Add parts with critical threshold
+        builder.with_parts(
+            vec![PartsMetrics {
+                database: "testdb".to_string(),
+                table: "events".to_string(),
+                active_parts: 1500,
+                ..Default::default()
+            }],
+            "sql",
+        );
+
+        // Add disk with warning threshold
+        builder.with_disk(
+            vec![DiskMetrics {
+                disk_name: "default".to_string(),
+                path: "/".to_string(),
+                total_space: 100_000_000_000,
+                free_space: 15_000_000_000,
+                free_percent: 15.0,
+            }],
+            "sql",
+        );
+
+        let registry = RuleRegistry::with_default_rules();
+        builder.run_rules(&registry);
+
+        let report = builder.build();
+        // Critical takes precedence
+        assert_eq!(report.summary.status, ReportStatus::Critical);
+    }
+
+    #[test]
+    fn test_builder_evidence_tracking() {
+        let mut builder = ReportBuilder::new(targets());
+        builder
+            .with_parts(vec![], "sql1")
+            .with_merges(vec![], "sql2")
+            .with_disk(vec![], "sql3");
+
+        let report = builder.build();
+        assert_eq!(report.evidence.len(), 3);
+    }
+}

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -1,2 +1,3 @@
-// Report module - report data structures
-// Implementation will be added in PR-07
+mod types;
+
+pub use types::*;

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -1,3 +1,5 @@
+mod builder;
 mod types;
 
+pub use builder::ReportBuilder;
 pub use types::*;

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -1,0 +1,2 @@
+// Report module - report data structures
+// Implementation will be added in PR-07

--- a/src/report/types.rs
+++ b/src/report/types.rs
@@ -1,0 +1,407 @@
+use serde::{Deserialize, Serialize};
+
+/// Main audit report structure
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Report {
+    pub report_version: String,
+    pub report_id: String,
+    pub generated_at: String,
+    pub targets: Targets,
+    pub summary: Summary,
+    pub sections: Sections,
+    pub findings: Vec<Finding>,
+    pub actions: Vec<Action>,
+    pub evidence: Vec<Evidence>,
+}
+
+impl Report {
+    pub fn new(targets: Targets) -> Self {
+        Self {
+            report_version: "1.0.0".to_string(),
+            report_id: uuid::Uuid::new_v4().to_string(),
+            generated_at: chrono::Utc::now().to_rfc3339(),
+            targets,
+            summary: Summary::default(),
+            sections: Sections::default(),
+            findings: Vec::new(),
+            actions: Vec::new(),
+            evidence: Vec::new(),
+        }
+    }
+}
+
+/// Audit targets (endpoint, database, tables)
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Targets {
+    pub endpoint: String,
+    pub database: String,
+    pub tables: Vec<String>,
+}
+
+/// Report summary with overall status
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct Summary {
+    pub status: ReportStatus,
+    pub findings_count: usize,
+    pub critical_count: usize,
+    pub warning_count: usize,
+}
+
+/// Overall report status
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ReportStatus {
+    #[default]
+    Healthy,
+    Warning,
+    Critical,
+}
+
+/// Report sections containing collected metrics
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct Sections {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parts: Option<PartsSection>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub merges: Option<MergesSection>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mutations: Option<MutationsSection>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disk: Option<DiskSection>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub query_log: Option<QueryLogSection>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mv_dag: Option<MvDagSection>,
+}
+
+/// Parts metrics section
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct PartsSection {
+    pub tables: Vec<PartsMetrics>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct PartsMetrics {
+    pub database: String,
+    pub table: String,
+    pub parts_count: u64,
+    pub active_parts: u64,
+    pub total_rows: u64,
+    pub bytes_on_disk: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub oldest_part: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub newest_part: Option<String>,
+}
+
+/// Merges metrics section
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct MergesSection {
+    pub tables: Vec<MergeMetrics>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct MergeMetrics {
+    pub database: String,
+    pub table: String,
+    pub merges_in_queue: u64,
+    pub merge_rows_read: u64,
+    pub merge_bytes_read: u64,
+    pub max_merge_elapsed_sec: f64,
+}
+
+/// Mutations metrics section
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct MutationsSection {
+    pub tables: Vec<MutationMetrics>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct MutationMetrics {
+    pub database: String,
+    pub table: String,
+    pub total_mutations: u64,
+    pub active_mutations: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub latest_mutation_time: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub oldest_active_mutation_age_sec: Option<u64>,
+}
+
+/// Disk metrics section
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct DiskSection {
+    pub disks: Vec<DiskMetrics>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct DiskMetrics {
+    pub disk_name: String,
+    pub path: String,
+    pub total_space: u64,
+    pub free_space: u64,
+    pub free_percent: f64,
+}
+
+/// Query log metrics section
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct QueryLogSection {
+    pub queries: Vec<QueryMetrics>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct QueryMetrics {
+    pub query_fingerprint: String,
+    pub execution_count: u64,
+    pub avg_duration_ms: f64,
+    pub total_read_rows: u64,
+    pub total_read_bytes: u64,
+    pub total_result_rows: u64,
+    pub read_amplification: f64,
+    pub avg_memory_bytes: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sample_query: Option<String>,
+}
+
+/// MV DAG section
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct MvDagSection {
+    pub nodes: Vec<MvDagNode>,
+    pub edges: Vec<MvDagEdge>,
+    pub max_depth: usize,
+    pub total_tables: usize,
+    pub total_mvs: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MvDagNode {
+    pub name: String,
+    pub database: String,
+    pub table_type: TableType,
+    pub engine: String,
+    pub depth: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TableType {
+    Table,
+    MaterializedView,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MvDagEdge {
+    pub from: String,
+    pub to: String,
+}
+
+/// Finding from rule evaluation
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Finding {
+    pub id: String,
+    pub rule_id: String,
+    pub severity: Severity,
+    pub target: String,
+    pub message: String,
+    pub evidence_refs: Vec<String>,
+    pub confidence: f64,
+}
+
+/// Finding severity level
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum Severity {
+    Warning,
+    Critical,
+}
+
+/// Recommended action
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Action {
+    pub id: String,
+    pub finding_ref: String,
+    pub action_type: ActionType,
+    pub priority: Priority,
+    pub description: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sql: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ActionType {
+    Recommendation,
+    DdlProposal,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum Priority {
+    High,
+    Medium,
+    Low,
+}
+
+/// Evidence linking findings to source data
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Evidence {
+    pub id: String,
+    pub source: String,
+    pub sql: String,
+    pub collected_at: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    fn sample_report() -> Report {
+        let targets = Targets {
+            endpoint: "http://localhost:8123".to_string(),
+            database: "testdb".to_string(),
+            tables: vec!["events".to_string()],
+        };
+        let mut report = Report::new(targets);
+        report.report_id = "test-id-123".to_string();
+        report.generated_at = "2024-01-15T10:30:00Z".to_string();
+        report
+    }
+
+    #[test]
+    fn test_report_json_roundtrip() {
+        let report = sample_report();
+
+        let json = serde_json::to_string_pretty(&report).unwrap();
+        let parsed: Report = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(report.report_id, parsed.report_id);
+        assert_eq!(report.targets, parsed.targets);
+        assert_eq!(report.summary.status, parsed.summary.status);
+    }
+
+    #[test]
+    fn test_report_status_serialization() {
+        assert_eq!(
+            serde_json::to_string(&ReportStatus::Healthy).unwrap(),
+            "\"healthy\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ReportStatus::Warning).unwrap(),
+            "\"warning\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ReportStatus::Critical).unwrap(),
+            "\"critical\""
+        );
+    }
+
+    #[test]
+    fn test_severity_serialization() {
+        assert_eq!(
+            serde_json::to_string(&Severity::Warning).unwrap(),
+            "\"warning\""
+        );
+        assert_eq!(
+            serde_json::to_string(&Severity::Critical).unwrap(),
+            "\"critical\""
+        );
+    }
+
+    #[test]
+    fn test_report_default_values() {
+        let report = sample_report();
+
+        assert_eq!(report.report_version, "1.0.0");
+        assert_eq!(report.summary.status, ReportStatus::Healthy);
+        assert_eq!(report.summary.findings_count, 0);
+        assert!(report.findings.is_empty());
+        assert!(report.actions.is_empty());
+    }
+
+    #[test]
+    fn test_parts_metrics_serialization() {
+        let metrics = PartsMetrics {
+            database: "testdb".to_string(),
+            table: "events".to_string(),
+            parts_count: 100,
+            active_parts: 50,
+            total_rows: 1_000_000,
+            bytes_on_disk: 500_000_000,
+            oldest_part: Some("2024-01-01T00:00:00Z".to_string()),
+            newest_part: Some("2024-01-15T00:00:00Z".to_string()),
+        };
+
+        let json = serde_json::to_string(&metrics).unwrap();
+        let parsed: PartsMetrics = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(metrics, parsed);
+    }
+
+    #[test]
+    fn test_finding_serialization() {
+        let finding = Finding {
+            id: "f-001".to_string(),
+            rule_id: "parts_explosion".to_string(),
+            severity: Severity::Warning,
+            target: "testdb.events".to_string(),
+            message: "Table has 500 active parts".to_string(),
+            evidence_refs: vec!["ev-001".to_string()],
+            confidence: 0.95,
+        };
+
+        let json = serde_json::to_string(&finding).unwrap();
+        assert!(json.contains("\"severity\":\"warning\""));
+        assert!(json.contains("\"rule_id\":\"parts_explosion\""));
+
+        let parsed: Finding = serde_json::from_str(&json).unwrap();
+        assert_eq!(finding, parsed);
+    }
+
+    #[test]
+    fn test_action_serialization() {
+        let action = Action {
+            id: "a-001".to_string(),
+            finding_ref: "f-001".to_string(),
+            action_type: ActionType::Recommendation,
+            priority: Priority::High,
+            description: "Run OPTIMIZE TABLE".to_string(),
+            sql: Some("OPTIMIZE TABLE testdb.events FINAL".to_string()),
+        };
+
+        let json = serde_json::to_string(&action).unwrap();
+        let parsed: Action = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(action, parsed);
+    }
+
+    #[test]
+    fn test_skip_serializing_none() {
+        let metrics = PartsMetrics {
+            database: "testdb".to_string(),
+            table: "events".to_string(),
+            parts_count: 100,
+            active_parts: 50,
+            total_rows: 1_000_000,
+            bytes_on_disk: 500_000_000,
+            oldest_part: None,
+            newest_part: None,
+        };
+
+        let json = serde_json::to_string(&metrics).unwrap();
+        assert!(!json.contains("oldest_part"));
+        assert!(!json.contains("newest_part"));
+    }
+
+    #[test]
+    fn test_table_type_serialization() {
+        assert_eq!(
+            serde_json::to_string(&TableType::Table).unwrap(),
+            "\"table\""
+        );
+        assert_eq!(
+            serde_json::to_string(&TableType::MaterializedView).unwrap(),
+            "\"materialized_view\""
+        );
+    }
+}

--- a/src/rules/context.rs
+++ b/src/rules/context.rs
@@ -1,0 +1,96 @@
+use crate::report::{DiskMetrics, MergeMetrics, MutationMetrics, PartsMetrics, QueryMetrics};
+use std::collections::HashMap;
+
+/// Context passed to rules for evaluation
+#[derive(Debug, Default)]
+pub struct AuditContext {
+    /// Parts metrics per table (key: "database.table")
+    pub parts: HashMap<String, PartsMetrics>,
+    /// Merge metrics per table
+    pub merges: HashMap<String, MergeMetrics>,
+    /// Mutation metrics per table
+    pub mutations: HashMap<String, MutationMetrics>,
+    /// Disk metrics (global)
+    pub disk: Vec<DiskMetrics>,
+    /// Query metrics
+    pub queries: Vec<QueryMetrics>,
+}
+
+impl AuditContext {
+    /// Create a new empty audit context
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add parts metrics for a table
+    pub fn add_parts(&mut self, metrics: PartsMetrics) {
+        let key = format!("{}.{}", metrics.database, metrics.table);
+        self.parts.insert(key, metrics);
+    }
+
+    /// Add merge metrics for a table
+    pub fn add_merges(&mut self, metrics: MergeMetrics) {
+        let key = format!("{}.{}", metrics.database, metrics.table);
+        self.merges.insert(key, metrics);
+    }
+
+    /// Add mutation metrics for a table
+    pub fn add_mutations(&mut self, metrics: MutationMetrics) {
+        let key = format!("{}.{}", metrics.database, metrics.table);
+        self.mutations.insert(key, metrics);
+    }
+
+    /// Set disk metrics
+    pub fn set_disk(&mut self, metrics: Vec<DiskMetrics>) {
+        self.disk = metrics;
+    }
+
+    /// Set query metrics
+    pub fn set_queries(&mut self, metrics: Vec<QueryMetrics>) {
+        self.queries = metrics;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_context_new() {
+        let ctx = AuditContext::new();
+        assert!(ctx.parts.is_empty());
+        assert!(ctx.merges.is_empty());
+        assert!(ctx.disk.is_empty());
+    }
+
+    #[test]
+    fn test_context_add_parts() {
+        let mut ctx = AuditContext::new();
+        ctx.add_parts(PartsMetrics {
+            database: "testdb".to_string(),
+            table: "events".to_string(),
+            active_parts: 100,
+            ..Default::default()
+        });
+
+        assert!(ctx.parts.contains_key("testdb.events"));
+        assert_eq!(ctx.parts["testdb.events"].active_parts, 100);
+    }
+
+    #[test]
+    fn test_context_add_multiple_tables() {
+        let mut ctx = AuditContext::new();
+        ctx.add_parts(PartsMetrics {
+            database: "db".to_string(),
+            table: "t1".to_string(),
+            ..Default::default()
+        });
+        ctx.add_parts(PartsMetrics {
+            database: "db".to_string(),
+            table: "t2".to_string(),
+            ..Default::default()
+        });
+
+        assert_eq!(ctx.parts.len(), 2);
+    }
+}

--- a/src/rules/disk.rs
+++ b/src/rules/disk.rs
@@ -1,5 +1,5 @@
-use crate::report::{Action, ActionType, Finding, Priority, Severity};
 use super::{AuditContext, Rule, RuleResult};
+use crate::report::{Action, ActionType, Finding, Priority, Severity};
 
 const DISK_WARNING_PCT: f64 = 20.0;
 const DISK_CRITICAL_PCT: f64 = 10.0;

--- a/src/rules/disk.rs
+++ b/src/rules/disk.rs
@@ -1,0 +1,131 @@
+use crate::report::{Action, ActionType, Finding, Priority, Severity};
+use super::{AuditContext, Rule, RuleResult};
+
+const DISK_WARNING_PCT: f64 = 20.0;
+const DISK_CRITICAL_PCT: f64 = 10.0;
+
+/// Rule to detect low disk headroom
+pub struct DiskHeadroomRule;
+
+impl Rule for DiskHeadroomRule {
+    fn id(&self) -> &'static str {
+        "disk_headroom"
+    }
+
+    fn name(&self) -> &'static str {
+        "Disk Headroom"
+    }
+
+    fn evaluate(&self, ctx: &AuditContext) -> Vec<RuleResult> {
+        let mut results = Vec::new();
+
+        for disk in &ctx.disk {
+            let free_pct = disk.free_percent;
+            let free_gb = disk.free_space as f64 / 1_073_741_824.0;
+
+            if free_pct < DISK_CRITICAL_PCT {
+                results.push(RuleResult {
+                    finding: Finding {
+                        id: format!("f-disk-{}", results.len() + 1),
+                        rule_id: self.id().to_string(),
+                        severity: Severity::Critical,
+                        target: disk.disk_name.clone(),
+                        message: format!(
+                            "Disk {} has only {:.1}% free ({:.1}GB)",
+                            disk.disk_name, free_pct, free_gb
+                        ),
+                        evidence_refs: vec![],
+                        confidence: 1.0,
+                    },
+                    actions: vec![Action {
+                        id: format!("a-disk-{}", results.len() + 1),
+                        finding_ref: format!("f-disk-{}", results.len() + 1),
+                        action_type: ActionType::Recommendation,
+                        priority: Priority::High,
+                        description: "Expand storage or implement TTL policy urgently".to_string(),
+                        sql: None,
+                    }],
+                });
+            } else if free_pct < DISK_WARNING_PCT {
+                results.push(RuleResult {
+                    finding: Finding {
+                        id: format!("f-disk-{}", results.len() + 1),
+                        rule_id: self.id().to_string(),
+                        severity: Severity::Warning,
+                        target: disk.disk_name.clone(),
+                        message: format!(
+                            "Disk {} has only {:.1}% free ({:.1}GB)",
+                            disk.disk_name, free_pct, free_gb
+                        ),
+                        evidence_refs: vec![],
+                        confidence: 1.0,
+                    },
+                    actions: vec![Action {
+                        id: format!("a-disk-{}", results.len() + 1),
+                        finding_ref: format!("f-disk-{}", results.len() + 1),
+                        action_type: ActionType::Recommendation,
+                        priority: Priority::Medium,
+                        description: "Consider expanding storage or implementing TTL".to_string(),
+                        sql: None,
+                    }],
+                });
+            }
+        }
+
+        results
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::report::DiskMetrics;
+
+    fn ctx_with_disk(free_percent: f64) -> AuditContext {
+        let mut ctx = AuditContext::new();
+        let total = 100_000_000_000u64;
+        let free = (total as f64 * free_percent / 100.0) as u64;
+        ctx.set_disk(vec![DiskMetrics {
+            disk_name: "default".to_string(),
+            path: "/var/lib/clickhouse".to_string(),
+            total_space: total,
+            free_space: free,
+            free_percent,
+        }]);
+        ctx
+    }
+
+    #[test]
+    fn test_disk_healthy() {
+        let rule = DiskHeadroomRule;
+        let ctx = ctx_with_disk(50.0);
+        let results = rule.evaluate(&ctx);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_disk_warning() {
+        let rule = DiskHeadroomRule;
+        let ctx = ctx_with_disk(15.0);
+        let results = rule.evaluate(&ctx);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].finding.severity, Severity::Warning);
+    }
+
+    #[test]
+    fn test_disk_critical() {
+        let rule = DiskHeadroomRule;
+        let ctx = ctx_with_disk(5.0);
+        let results = rule.evaluate(&ctx);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].finding.severity, Severity::Critical);
+    }
+
+    #[test]
+    fn test_disk_at_warning_threshold() {
+        let rule = DiskHeadroomRule;
+        let ctx = ctx_with_disk(20.0);
+        let results = rule.evaluate(&ctx);
+        assert!(results.is_empty());
+    }
+}

--- a/src/rules/engine.rs
+++ b/src/rules/engine.rs
@@ -1,0 +1,171 @@
+use crate::report::{Action, Finding};
+use super::context::AuditContext;
+
+/// Result of a rule evaluation
+#[derive(Debug)]
+pub struct RuleResult {
+    pub finding: Finding,
+    pub actions: Vec<Action>,
+}
+
+/// Trait for implementing audit rules
+pub trait Rule: Send + Sync {
+    /// Unique identifier for the rule
+    fn id(&self) -> &'static str;
+
+    /// Human-readable name
+    fn name(&self) -> &'static str;
+
+    /// Evaluate the rule against the audit context
+    fn evaluate(&self, ctx: &AuditContext) -> Vec<RuleResult>;
+}
+
+/// Registry for managing and running rules
+#[derive(Default)]
+pub struct RuleRegistry {
+    rules: Vec<Box<dyn Rule>>,
+}
+
+impl RuleRegistry {
+    /// Create a new empty rule registry
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a rule
+    pub fn register(&mut self, rule: Box<dyn Rule>) {
+        self.rules.push(rule);
+    }
+
+    /// Evaluate all rules against the context
+    pub fn evaluate_all(&self, ctx: &AuditContext) -> Vec<RuleResult> {
+        self.rules
+            .iter()
+            .flat_map(|rule| rule.evaluate(ctx))
+            .collect()
+    }
+
+    /// Get the number of registered rules
+    pub fn len(&self) -> usize {
+        self.rules.len()
+    }
+
+    /// Check if registry is empty
+    pub fn is_empty(&self) -> bool {
+        self.rules.is_empty()
+    }
+
+    /// Get list of registered rule IDs
+    pub fn rule_ids(&self) -> Vec<&'static str> {
+        self.rules.iter().map(|r| r.id()).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::report::Severity;
+
+    // Mock rule for testing
+    struct MockRule {
+        should_trigger: bool,
+    }
+
+    impl Rule for MockRule {
+        fn id(&self) -> &'static str {
+            "mock_rule"
+        }
+
+        fn name(&self) -> &'static str {
+            "Mock Rule"
+        }
+
+        fn evaluate(&self, _ctx: &AuditContext) -> Vec<RuleResult> {
+            if self.should_trigger {
+                vec![RuleResult {
+                    finding: Finding {
+                        id: "f-mock".to_string(),
+                        rule_id: self.id().to_string(),
+                        severity: Severity::Warning,
+                        target: "test".to_string(),
+                        message: "Mock finding".to_string(),
+                        evidence_refs: vec![],
+                        confidence: 1.0,
+                    },
+                    actions: vec![],
+                }]
+            } else {
+                vec![]
+            }
+        }
+    }
+
+    #[test]
+    fn test_registry_empty() {
+        let registry = RuleRegistry::new();
+        assert!(registry.is_empty());
+        assert_eq!(registry.len(), 0);
+    }
+
+    #[test]
+    fn test_registry_register() {
+        let mut registry = RuleRegistry::new();
+        registry.register(Box::new(MockRule { should_trigger: false }));
+
+        assert!(!registry.is_empty());
+        assert_eq!(registry.len(), 1);
+    }
+
+    #[test]
+    fn test_registry_evaluate_empty() {
+        let registry = RuleRegistry::new();
+        let ctx = AuditContext::new();
+
+        let results = registry.evaluate_all(&ctx);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_registry_evaluate_no_trigger() {
+        let mut registry = RuleRegistry::new();
+        registry.register(Box::new(MockRule { should_trigger: false }));
+
+        let ctx = AuditContext::new();
+        let results = registry.evaluate_all(&ctx);
+
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_registry_evaluate_trigger() {
+        let mut registry = RuleRegistry::new();
+        registry.register(Box::new(MockRule { should_trigger: true }));
+
+        let ctx = AuditContext::new();
+        let results = registry.evaluate_all(&ctx);
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].finding.rule_id, "mock_rule");
+    }
+
+    #[test]
+    fn test_registry_multiple_rules() {
+        let mut registry = RuleRegistry::new();
+        registry.register(Box::new(MockRule { should_trigger: true }));
+        registry.register(Box::new(MockRule { should_trigger: true }));
+
+        let ctx = AuditContext::new();
+        let results = registry.evaluate_all(&ctx);
+
+        assert_eq!(results.len(), 2);
+    }
+
+    #[test]
+    fn test_registry_rule_ids() {
+        let mut registry = RuleRegistry::new();
+        registry.register(Box::new(MockRule { should_trigger: false }));
+
+        let ids = registry.rule_ids();
+        assert_eq!(ids, vec!["mock_rule"]);
+    }
+}

--- a/src/rules/engine.rs
+++ b/src/rules/engine.rs
@@ -1,5 +1,5 @@
-use crate::report::{Action, Finding};
 use super::context::AuditContext;
+use crate::report::{Action, Finding};
 
 /// Result of a rule evaluation
 #[derive(Debug)]
@@ -110,7 +110,9 @@ mod tests {
     #[test]
     fn test_registry_register() {
         let mut registry = RuleRegistry::new();
-        registry.register(Box::new(MockRule { should_trigger: false }));
+        registry.register(Box::new(MockRule {
+            should_trigger: false,
+        }));
 
         assert!(!registry.is_empty());
         assert_eq!(registry.len(), 1);
@@ -128,7 +130,9 @@ mod tests {
     #[test]
     fn test_registry_evaluate_no_trigger() {
         let mut registry = RuleRegistry::new();
-        registry.register(Box::new(MockRule { should_trigger: false }));
+        registry.register(Box::new(MockRule {
+            should_trigger: false,
+        }));
 
         let ctx = AuditContext::new();
         let results = registry.evaluate_all(&ctx);
@@ -139,7 +143,9 @@ mod tests {
     #[test]
     fn test_registry_evaluate_trigger() {
         let mut registry = RuleRegistry::new();
-        registry.register(Box::new(MockRule { should_trigger: true }));
+        registry.register(Box::new(MockRule {
+            should_trigger: true,
+        }));
 
         let ctx = AuditContext::new();
         let results = registry.evaluate_all(&ctx);
@@ -151,8 +157,12 @@ mod tests {
     #[test]
     fn test_registry_multiple_rules() {
         let mut registry = RuleRegistry::new();
-        registry.register(Box::new(MockRule { should_trigger: true }));
-        registry.register(Box::new(MockRule { should_trigger: true }));
+        registry.register(Box::new(MockRule {
+            should_trigger: true,
+        }));
+        registry.register(Box::new(MockRule {
+            should_trigger: true,
+        }));
 
         let ctx = AuditContext::new();
         let results = registry.evaluate_all(&ctx);
@@ -163,7 +173,9 @@ mod tests {
     #[test]
     fn test_registry_rule_ids() {
         let mut registry = RuleRegistry::new();
-        registry.register(Box::new(MockRule { should_trigger: false }));
+        registry.register(Box::new(MockRule {
+            should_trigger: false,
+        }));
 
         let ids = registry.rule_ids();
         assert_eq!(ids, vec!["mock_rule"]);

--- a/src/rules/merges.rs
+++ b/src/rules/merges.rs
@@ -1,5 +1,5 @@
-use crate::report::{Action, ActionType, Finding, Priority, Severity};
 use super::{AuditContext, Rule, RuleResult};
+use crate::report::{Action, ActionType, Finding, Priority, Severity};
 
 const MERGE_QUEUE_WARNING: u64 = 10;
 const MERGE_ELAPSED_WARNING_SEC: f64 = 3600.0; // 1 hour

--- a/src/rules/merges.rs
+++ b/src/rules/merges.rs
@@ -1,0 +1,122 @@
+use crate::report::{Action, ActionType, Finding, Priority, Severity};
+use super::{AuditContext, Rule, RuleResult};
+
+const MERGE_QUEUE_WARNING: u64 = 10;
+const MERGE_ELAPSED_WARNING_SEC: f64 = 3600.0; // 1 hour
+
+/// Rule to detect merge backlog
+pub struct MergeBacklogRule;
+
+impl Rule for MergeBacklogRule {
+    fn id(&self) -> &'static str {
+        "merge_backlog"
+    }
+
+    fn name(&self) -> &'static str {
+        "Merge Backlog"
+    }
+
+    fn evaluate(&self, ctx: &AuditContext) -> Vec<RuleResult> {
+        let mut results = Vec::new();
+
+        for (table_key, metrics) in &ctx.merges {
+            let queue_high = metrics.merges_in_queue > MERGE_QUEUE_WARNING;
+            let elapsed_high = metrics.max_merge_elapsed_sec > MERGE_ELAPSED_WARNING_SEC;
+
+            if queue_high || elapsed_high {
+                let message = if queue_high && elapsed_high {
+                    format!(
+                        "Merge queue has {} items and longest merge running for {:.0}s",
+                        metrics.merges_in_queue, metrics.max_merge_elapsed_sec
+                    )
+                } else if queue_high {
+                    format!(
+                        "Merge queue has {} items (threshold: {})",
+                        metrics.merges_in_queue, MERGE_QUEUE_WARNING
+                    )
+                } else {
+                    format!(
+                        "Longest merge running for {:.0}s (threshold: {:.0}s)",
+                        metrics.max_merge_elapsed_sec, MERGE_ELAPSED_WARNING_SEC
+                    )
+                };
+
+                results.push(RuleResult {
+                    finding: Finding {
+                        id: format!("f-merge-{}", results.len() + 1),
+                        rule_id: self.id().to_string(),
+                        severity: Severity::Warning,
+                        target: table_key.clone(),
+                        message,
+                        evidence_refs: vec![],
+                        confidence: 1.0,
+                    },
+                    actions: vec![Action {
+                        id: format!("a-merge-{}", results.len() + 1),
+                        finding_ref: format!("f-merge-{}", results.len() + 1),
+                        action_type: ActionType::Recommendation,
+                        priority: Priority::Medium,
+                        description: "Review write rate, consider throttling ingestion".to_string(),
+                        sql: None,
+                    }],
+                });
+            }
+        }
+
+        results
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::report::MergeMetrics;
+
+    fn ctx_with_merges(queue: u64, elapsed: f64) -> AuditContext {
+        let mut ctx = AuditContext::new();
+        ctx.add_merges(MergeMetrics {
+            database: "testdb".to_string(),
+            table: "events".to_string(),
+            merges_in_queue: queue,
+            max_merge_elapsed_sec: elapsed,
+            ..Default::default()
+        });
+        ctx
+    }
+
+    #[test]
+    fn test_merge_backlog_healthy() {
+        let rule = MergeBacklogRule;
+        let ctx = ctx_with_merges(5, 100.0);
+        let results = rule.evaluate(&ctx);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_merge_backlog_queue_warning() {
+        let rule = MergeBacklogRule;
+        let ctx = ctx_with_merges(15, 100.0);
+        let results = rule.evaluate(&ctx);
+        assert_eq!(results.len(), 1);
+        assert!(results[0].finding.message.contains("15 items"));
+    }
+
+    #[test]
+    fn test_merge_backlog_elapsed_warning() {
+        let rule = MergeBacklogRule;
+        let ctx = ctx_with_merges(5, 7200.0);
+        let results = rule.evaluate(&ctx);
+        assert_eq!(results.len(), 1);
+        assert!(results[0].finding.message.contains("7200s"));
+    }
+
+    #[test]
+    fn test_merge_backlog_both() {
+        let rule = MergeBacklogRule;
+        let ctx = ctx_with_merges(15, 7200.0);
+        let results = rule.evaluate(&ctx);
+        assert_eq!(results.len(), 1);
+        assert!(results[0].finding.message.contains("15 items"));
+        assert!(results[0].finding.message.contains("7200s"));
+    }
+}

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -1,2 +1,5 @@
-// Rules module - finding and action generation
-// Implementation will be added in PR-14 to PR-19
+mod context;
+mod engine;
+
+pub use context::AuditContext;
+pub use engine::{Rule, RuleRegistry, RuleResult};

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -1,5 +1,7 @@
 mod context;
 mod engine;
+mod parts;
 
 pub use context::AuditContext;
 pub use engine::{Rule, RuleRegistry, RuleResult};
+pub use parts::PartsExplosionRule;

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -1,0 +1,2 @@
+// Rules module - finding and action generation
+// Implementation will be added in PR-14 to PR-19

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -1,7 +1,28 @@
 mod context;
+mod disk;
 mod engine;
+mod merges;
+mod mutations;
 mod parts;
+mod query;
 
 pub use context::AuditContext;
+pub use disk::DiskHeadroomRule;
 pub use engine::{Rule, RuleRegistry, RuleResult};
+pub use merges::MergeBacklogRule;
+pub use mutations::StuckMutationRule;
 pub use parts::PartsExplosionRule;
+pub use query::QueryAmplificationRule;
+
+impl RuleRegistry {
+    /// Create a registry with all default rules
+    pub fn with_default_rules() -> Self {
+        let mut registry = Self::new();
+        registry.register(Box::new(PartsExplosionRule));
+        registry.register(Box::new(MergeBacklogRule));
+        registry.register(Box::new(DiskHeadroomRule));
+        registry.register(Box::new(QueryAmplificationRule));
+        registry.register(Box::new(StuckMutationRule));
+        registry
+    }
+}

--- a/src/rules/mutations.rs
+++ b/src/rules/mutations.rs
@@ -1,5 +1,5 @@
-use crate::report::{Action, ActionType, Finding, Priority, Severity};
 use super::{AuditContext, Rule, RuleResult};
+use crate::report::{Action, ActionType, Finding, Priority, Severity};
 
 const MUTATION_STUCK_SEC: u64 = 3600; // 1 hour
 
@@ -113,6 +113,10 @@ mod tests {
         let ctx = ctx_with_mutations(1, Some(7200));
         let results = rule.evaluate(&ctx);
         assert!(results[0].actions[0].sql.is_some());
-        assert!(results[0].actions[0].sql.as_ref().unwrap().contains("system.mutations"));
+        assert!(results[0].actions[0]
+            .sql
+            .as_ref()
+            .unwrap()
+            .contains("system.mutations"));
     }
 }

--- a/src/rules/mutations.rs
+++ b/src/rules/mutations.rs
@@ -1,0 +1,118 @@
+use crate::report::{Action, ActionType, Finding, Priority, Severity};
+use super::{AuditContext, Rule, RuleResult};
+
+const MUTATION_STUCK_SEC: u64 = 3600; // 1 hour
+
+/// Rule to detect stuck mutations
+pub struct StuckMutationRule;
+
+impl Rule for StuckMutationRule {
+    fn id(&self) -> &'static str {
+        "stuck_mutation"
+    }
+
+    fn name(&self) -> &'static str {
+        "Stuck Mutation"
+    }
+
+    fn evaluate(&self, ctx: &AuditContext) -> Vec<RuleResult> {
+        let mut results = Vec::new();
+
+        for (table_key, metrics) in &ctx.mutations {
+            if metrics.active_mutations > 0 {
+                if let Some(age) = metrics.oldest_active_mutation_age_sec {
+                    if age > MUTATION_STUCK_SEC {
+                        let hours = age as f64 / 3600.0;
+                        results.push(RuleResult {
+                            finding: Finding {
+                                id: format!("f-mutation-{}", results.len() + 1),
+                                rule_id: self.id().to_string(),
+                                severity: Severity::Critical,
+                                target: table_key.clone(),
+                                message: format!(
+                                    "Mutation running for {:.1} hours (threshold: 1 hour)",
+                                    hours
+                                ),
+                                evidence_refs: vec![],
+                                confidence: 1.0,
+                            },
+                            actions: vec![Action {
+                                id: format!("a-mutation-{}", results.len() + 1),
+                                finding_ref: format!("f-mutation-{}", results.len() + 1),
+                                action_type: ActionType::Recommendation,
+                                priority: Priority::High,
+                                description: "Investigate mutation, consider KILL MUTATION if stuck".to_string(),
+                                sql: Some(format!(
+                                    "SELECT * FROM system.mutations WHERE database = '{}' AND table = '{}' AND is_done = 0",
+                                    metrics.database, metrics.table
+                                )),
+                            }],
+                        });
+                    }
+                }
+            }
+        }
+
+        results
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::report::MutationMetrics;
+
+    fn ctx_with_mutations(active: u64, age_sec: Option<u64>) -> AuditContext {
+        let mut ctx = AuditContext::new();
+        ctx.add_mutations(MutationMetrics {
+            database: "testdb".to_string(),
+            table: "events".to_string(),
+            active_mutations: active,
+            oldest_active_mutation_age_sec: age_sec,
+            ..Default::default()
+        });
+        ctx
+    }
+
+    #[test]
+    fn test_mutation_none() {
+        let rule = StuckMutationRule;
+        let ctx = ctx_with_mutations(0, None);
+        let results = rule.evaluate(&ctx);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_mutation_active_recent() {
+        let rule = StuckMutationRule;
+        let ctx = ctx_with_mutations(1, Some(600)); // 10 minutes
+        let results = rule.evaluate(&ctx);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_mutation_stuck() {
+        let rule = StuckMutationRule;
+        let ctx = ctx_with_mutations(1, Some(7200)); // 2 hours
+        let results = rule.evaluate(&ctx);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].finding.severity, Severity::Critical);
+    }
+
+    #[test]
+    fn test_mutation_at_threshold() {
+        let rule = StuckMutationRule;
+        let ctx = ctx_with_mutations(1, Some(3600)); // exactly 1 hour
+        let results = rule.evaluate(&ctx);
+        assert!(results.is_empty()); // 3600 is NOT > 3600
+    }
+
+    #[test]
+    fn test_mutation_action_has_sql() {
+        let rule = StuckMutationRule;
+        let ctx = ctx_with_mutations(1, Some(7200));
+        let results = rule.evaluate(&ctx);
+        assert!(results[0].actions[0].sql.is_some());
+        assert!(results[0].actions[0].sql.as_ref().unwrap().contains("system.mutations"));
+    }
+}

--- a/src/rules/parts.rs
+++ b/src/rules/parts.rs
@@ -1,0 +1,190 @@
+use crate::report::{Action, ActionType, Finding, Priority, Severity};
+use super::{AuditContext, Rule, RuleResult};
+
+/// Thresholds for parts explosion detection
+const PARTS_WARNING: u64 = 300;
+const PARTS_CRITICAL: u64 = 1000;
+
+/// Rule to detect parts explosion in tables
+pub struct PartsExplosionRule;
+
+impl Rule for PartsExplosionRule {
+    fn id(&self) -> &'static str {
+        "parts_explosion"
+    }
+
+    fn name(&self) -> &'static str {
+        "Parts Explosion"
+    }
+
+    fn evaluate(&self, ctx: &AuditContext) -> Vec<RuleResult> {
+        let mut results = Vec::new();
+
+        for (table_key, metrics) in &ctx.parts {
+            let active_parts = metrics.active_parts;
+
+            if active_parts > PARTS_CRITICAL {
+                results.push(RuleResult {
+                    finding: Finding {
+                        id: format!("f-parts-{}", results.len() + 1),
+                        rule_id: self.id().to_string(),
+                        severity: Severity::Critical,
+                        target: table_key.clone(),
+                        message: format!(
+                            "Table has {} active parts, exceeding critical threshold of {}",
+                            active_parts, PARTS_CRITICAL
+                        ),
+                        evidence_refs: vec![],
+                        confidence: 1.0,
+                    },
+                    actions: vec![Action {
+                        id: format!("a-parts-{}", results.len() + 1),
+                        finding_ref: format!("f-parts-{}", results.len() + 1),
+                        action_type: ActionType::Recommendation,
+                        priority: Priority::High,
+                        description: "Run OPTIMIZE TABLE to reduce parts count".to_string(),
+                        sql: Some(format!("OPTIMIZE TABLE {} FINAL", table_key)),
+                    }],
+                });
+            } else if active_parts > PARTS_WARNING {
+                results.push(RuleResult {
+                    finding: Finding {
+                        id: format!("f-parts-{}", results.len() + 1),
+                        rule_id: self.id().to_string(),
+                        severity: Severity::Warning,
+                        target: table_key.clone(),
+                        message: format!(
+                            "Table has {} active parts, exceeding warning threshold of {}",
+                            active_parts, PARTS_WARNING
+                        ),
+                        evidence_refs: vec![],
+                        confidence: 1.0,
+                    },
+                    actions: vec![Action {
+                        id: format!("a-parts-{}", results.len() + 1),
+                        finding_ref: format!("f-parts-{}", results.len() + 1),
+                        action_type: ActionType::Recommendation,
+                        priority: Priority::Medium,
+                        description: "Consider running OPTIMIZE TABLE to reduce parts".to_string(),
+                        sql: Some(format!("OPTIMIZE TABLE {} FINAL", table_key)),
+                    }],
+                });
+            }
+        }
+
+        results
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::report::PartsMetrics;
+
+    fn ctx_with_parts(active_parts: u64) -> AuditContext {
+        let mut ctx = AuditContext::new();
+        ctx.add_parts(PartsMetrics {
+            database: "testdb".to_string(),
+            table: "events".to_string(),
+            active_parts,
+            ..Default::default()
+        });
+        ctx
+    }
+
+    #[test]
+    fn test_parts_explosion_healthy() {
+        let rule = PartsExplosionRule;
+        let ctx = ctx_with_parts(100); // below 300 threshold
+
+        let results = rule.evaluate(&ctx);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_parts_explosion_warning() {
+        let rule = PartsExplosionRule;
+        let ctx = ctx_with_parts(500); // between 300 and 1000
+
+        let results = rule.evaluate(&ctx);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].finding.severity, Severity::Warning);
+        assert_eq!(results[0].finding.rule_id, "parts_explosion");
+    }
+
+    #[test]
+    fn test_parts_explosion_critical() {
+        let rule = PartsExplosionRule;
+        let ctx = ctx_with_parts(1500); // above 1000
+
+        let results = rule.evaluate(&ctx);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].finding.severity, Severity::Critical);
+    }
+
+    #[test]
+    fn test_parts_explosion_at_warning_threshold() {
+        let rule = PartsExplosionRule;
+        let ctx = ctx_with_parts(300); // exactly at threshold
+
+        let results = rule.evaluate(&ctx);
+        assert!(results.is_empty()); // 300 is NOT > 300
+    }
+
+    #[test]
+    fn test_parts_explosion_just_above_warning() {
+        let rule = PartsExplosionRule;
+        let ctx = ctx_with_parts(301);
+
+        let results = rule.evaluate(&ctx);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].finding.severity, Severity::Warning);
+    }
+
+    #[test]
+    fn test_parts_explosion_action_has_sql() {
+        let rule = PartsExplosionRule;
+        let ctx = ctx_with_parts(1500);
+
+        let results = rule.evaluate(&ctx);
+        assert!(!results[0].actions.is_empty());
+        assert!(results[0].actions[0].sql.as_ref().unwrap().contains("OPTIMIZE"));
+    }
+
+    #[test]
+    fn test_parts_explosion_target_is_table() {
+        let rule = PartsExplosionRule;
+        let ctx = ctx_with_parts(1500);
+
+        let results = rule.evaluate(&ctx);
+        assert_eq!(results[0].finding.target, "testdb.events");
+    }
+
+    #[test]
+    fn test_parts_explosion_multiple_tables() {
+        let rule = PartsExplosionRule;
+        let mut ctx = AuditContext::new();
+
+        ctx.add_parts(PartsMetrics {
+            database: "db".to_string(),
+            table: "healthy".to_string(),
+            active_parts: 50,
+            ..Default::default()
+        });
+        ctx.add_parts(PartsMetrics {
+            database: "db".to_string(),
+            table: "warning".to_string(),
+            active_parts: 500,
+            ..Default::default()
+        });
+        ctx.add_parts(PartsMetrics {
+            database: "db".to_string(),
+            table: "critical".to_string(),
+            active_parts: 1500,
+            ..Default::default()
+        });
+
+        let results = rule.evaluate(&ctx);
+        assert_eq!(results.len(), 2); // warning + critical, not healthy
+    }
+}

--- a/src/rules/parts.rs
+++ b/src/rules/parts.rs
@@ -1,5 +1,5 @@
-use crate::report::{Action, ActionType, Finding, Priority, Severity};
 use super::{AuditContext, Rule, RuleResult};
+use crate::report::{Action, ActionType, Finding, Priority, Severity};
 
 /// Thresholds for parts explosion detection
 const PARTS_WARNING: u64 = 300;
@@ -148,7 +148,11 @@ mod tests {
 
         let results = rule.evaluate(&ctx);
         assert!(!results[0].actions.is_empty());
-        assert!(results[0].actions[0].sql.as_ref().unwrap().contains("OPTIMIZE"));
+        assert!(results[0].actions[0]
+            .sql
+            .as_ref()
+            .unwrap()
+            .contains("OPTIMIZE"));
     }
 
     #[test]

--- a/src/rules/query.rs
+++ b/src/rules/query.rs
@@ -1,5 +1,5 @@
-use crate::report::{Action, ActionType, Finding, Priority, Severity};
 use super::{AuditContext, Rule, RuleResult};
+use crate::report::{Action, ActionType, Finding, Priority, Severity};
 
 const READ_AMP_WARNING: f64 = 100.0;
 const READ_AMP_CRITICAL: f64 = 1000.0;

--- a/src/rules/query.rs
+++ b/src/rules/query.rs
@@ -1,0 +1,151 @@
+use crate::report::{Action, ActionType, Finding, Priority, Severity};
+use super::{AuditContext, Rule, RuleResult};
+
+const READ_AMP_WARNING: f64 = 100.0;
+const READ_AMP_CRITICAL: f64 = 1000.0;
+
+/// Rule to detect high read amplification in queries
+pub struct QueryAmplificationRule;
+
+impl Rule for QueryAmplificationRule {
+    fn id(&self) -> &'static str {
+        "query_amplification"
+    }
+
+    fn name(&self) -> &'static str {
+        "Query Read Amplification"
+    }
+
+    fn evaluate(&self, ctx: &AuditContext) -> Vec<RuleResult> {
+        let mut results = Vec::new();
+
+        for query in &ctx.queries {
+            let amp = query.read_amplification;
+
+            if amp > READ_AMP_CRITICAL {
+                results.push(RuleResult {
+                    finding: Finding {
+                        id: format!("f-query-{}", results.len() + 1),
+                        rule_id: self.id().to_string(),
+                        severity: Severity::Critical,
+                        target: truncate_fingerprint(&query.query_fingerprint),
+                        message: format!(
+                            "Query has {:.0}x read amplification (critical threshold: {:.0}x)",
+                            amp, READ_AMP_CRITICAL
+                        ),
+                        evidence_refs: vec![],
+                        confidence: 1.0,
+                    },
+                    actions: vec![Action {
+                        id: format!("a-query-{}", results.len() + 1),
+                        finding_ref: format!("f-query-{}", results.len() + 1),
+                        action_type: ActionType::Recommendation,
+                        priority: Priority::High,
+                        description: "Review query, add PREWHERE or adjust ORDER BY".to_string(),
+                        sql: None,
+                    }],
+                });
+            } else if amp > READ_AMP_WARNING {
+                results.push(RuleResult {
+                    finding: Finding {
+                        id: format!("f-query-{}", results.len() + 1),
+                        rule_id: self.id().to_string(),
+                        severity: Severity::Warning,
+                        target: truncate_fingerprint(&query.query_fingerprint),
+                        message: format!(
+                            "Query has {:.0}x read amplification (warning threshold: {:.0}x)",
+                            amp, READ_AMP_WARNING
+                        ),
+                        evidence_refs: vec![],
+                        confidence: 1.0,
+                    },
+                    actions: vec![Action {
+                        id: format!("a-query-{}", results.len() + 1),
+                        finding_ref: format!("f-query-{}", results.len() + 1),
+                        action_type: ActionType::Recommendation,
+                        priority: Priority::Medium,
+                        description: "Consider optimizing query pattern".to_string(),
+                        sql: None,
+                    }],
+                });
+            }
+        }
+
+        results
+    }
+}
+
+fn truncate_fingerprint(fp: &str) -> String {
+    if fp.len() > 80 {
+        format!("{}...", &fp[..77])
+    } else {
+        fp.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::report::QueryMetrics;
+
+    fn ctx_with_query_amp(amp: f64) -> AuditContext {
+        let mut ctx = AuditContext::new();
+        ctx.set_queries(vec![QueryMetrics {
+            query_fingerprint: "SELECT * FROM events WHERE user_id = ?".to_string(),
+            read_amplification: amp,
+            ..Default::default()
+        }]);
+        ctx
+    }
+
+    #[test]
+    fn test_query_amp_healthy() {
+        let rule = QueryAmplificationRule;
+        let ctx = ctx_with_query_amp(50.0);
+        let results = rule.evaluate(&ctx);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_query_amp_warning() {
+        let rule = QueryAmplificationRule;
+        let ctx = ctx_with_query_amp(500.0);
+        let results = rule.evaluate(&ctx);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].finding.severity, Severity::Warning);
+    }
+
+    #[test]
+    fn test_query_amp_critical() {
+        let rule = QueryAmplificationRule;
+        let ctx = ctx_with_query_amp(2000.0);
+        let results = rule.evaluate(&ctx);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].finding.severity, Severity::Critical);
+    }
+
+    #[test]
+    fn test_query_amp_multiple() {
+        let rule = QueryAmplificationRule;
+        let mut ctx = AuditContext::new();
+        ctx.set_queries(vec![
+            QueryMetrics {
+                query_fingerprint: "q1".to_string(),
+                read_amplification: 50.0,
+                ..Default::default()
+            },
+            QueryMetrics {
+                query_fingerprint: "q2".to_string(),
+                read_amplification: 500.0,
+                ..Default::default()
+            },
+            QueryMetrics {
+                query_fingerprint: "q3".to_string(),
+                read_amplification: 2000.0,
+                ..Default::default()
+            },
+        ]);
+        let results = rule.evaluate(&ctx);
+        assert_eq!(results.len(), 2); // warning + critical, not healthy
+    }
+}

--- a/tests/fixtures/init.sql
+++ b/tests/fixtures/init.sql
@@ -1,0 +1,60 @@
+-- PipeAudit Test Database Setup
+-- This file is executed on ClickHouse container startup
+
+-- Create test database
+CREATE DATABASE IF NOT EXISTS testdb;
+
+-- Scenario 1: Healthy table with normal parts count
+CREATE TABLE testdb.events (
+    event_date Date,
+    event_time DateTime,
+    user_id UInt64,
+    event_type LowCardinality(String),
+    payload String
+) ENGINE = MergeTree()
+PARTITION BY toYYYYMM(event_date)
+ORDER BY (event_date, user_id, event_time);
+
+-- Insert test data for healthy table
+INSERT INTO testdb.events
+SELECT
+    today() - (number % 30) AS event_date,
+    now() - (number * 60) AS event_time,
+    rand() % 10000 AS user_id,
+    ['click', 'view', 'purchase'][(number % 3) + 1] AS event_type,
+    concat('payload_', toString(number)) AS payload
+FROM numbers(10000);
+
+-- Scenario 2: Table for MV chain testing
+CREATE TABLE testdb.events_raw (
+    event_date Date,
+    event_time DateTime,
+    user_id UInt64,
+    event_type String,
+    value Float64
+) ENGINE = MergeTree()
+PARTITION BY toYYYYMM(event_date)
+ORDER BY (event_date, user_id);
+
+-- Materialized View: Daily aggregation
+CREATE MATERIALIZED VIEW testdb.events_daily_mv
+ENGINE = SummingMergeTree()
+PARTITION BY toYYYYMM(event_date)
+ORDER BY (event_date, event_type)
+AS SELECT
+    event_date,
+    event_type,
+    count() AS event_count,
+    sum(value) AS total_value
+FROM testdb.events_raw
+GROUP BY event_date, event_type;
+
+-- Insert data into raw table (will populate MV)
+INSERT INTO testdb.events_raw
+SELECT
+    today() - (number % 7) AS event_date,
+    now() - (number * 300) AS event_time,
+    rand() % 1000 AS user_id,
+    ['sale', 'refund', 'view'][(number % 3) + 1] AS event_type,
+    (rand() % 10000) / 100.0 AS value
+FROM numbers(5000);


### PR DESCRIPTION
## Summary

- Wires all components together in the main `run_audit` function
- Connects to ClickHouse and verifies connection with ping
- Runs all 6 collectors: parts, merges, mutations, disk, query_log, mv_dag
- Passes collected metrics to ReportBuilder with evidence SQL
- Runs rules engine with all 5 default rules
- Builds final report and outputs JSON + summary

## Changes

- `src/main.rs`: Implement full audit flow connecting all modules

## Test Plan

- [ ] `cargo build` - passes
- [ ] `cargo test` - all unit tests pass
- [ ] Manual test with real ClickHouse (requires PR-25 integration tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)